### PR TITLE
Box2DWorld querying API

### DIFF
--- a/register_types.cpp
+++ b/register_types.cpp
@@ -17,6 +17,7 @@ void register_godot_box2d_types() {
 	GLOBAL_DEF("physics/2d/box2d_conversion_factor", 50.0f);
 	ProjectSettings::get_singleton()->set_custom_property_info("physics/2d/box2d_conversion_factor", PropertyInfo(Variant::FLOAT, "physics/2d/box2d_conversion_factor"));
 
+	ClassDB::register_class<Box2DShapeQueryParameters>();
 	ClassDB::register_class<Box2DWorld>();
 	ClassDB::register_class<Box2DPhysicsBody>();
 	ClassDB::register_class<Box2DFixture>();

--- a/scene/2d/box2d_world.cpp
+++ b/scene/2d/box2d_world.cpp
@@ -712,9 +712,6 @@ Array Box2DWorld::intersect_point(const Vector2 &p_point, int p_max_results, con
 	Array arr;
 	arr.resize(n);
 
-	if (n > 0)
-		ERR_PRINT_ONCE("hey we do have results tho");
-
 	int i = 0;
 	for (auto element = point_callback.results.front(); element; element = element->next()) {
 		Box2DFixture *fixture = element->get();

--- a/scene/2d/box2d_world.cpp
+++ b/scene/2d/box2d_world.cpp
@@ -1083,11 +1083,12 @@ endloop:
 
 bool Box2DWorld::UserAABBQueryCallback::ReportFixture(b2Fixture *fixture) {
 	const int argcount = 1;
-	Variant args[argcount] = {
+	Variant arg0 = Variant(fixture->GetUserData().owner);
+	Variant *args[argcount] = {
 		// TODO what arguments do we give? Box2DFixture? Maybe AABB too?
 		// hard to tell because of composite fixtures
 		// If we return Box2DFixture, the query may report the same fixture several times.
-		Variant(fixture->GetUserData().owner)
+		&arg0
 	};
 	Variant ret;
 	Callable::CallError ce;
@@ -1099,16 +1100,25 @@ bool Box2DWorld::UserAABBQueryCallback::ReportFixture(b2Fixture *fixture) {
 		return false;
 	}
 
-	return bool(ret);
+	if (ret.get_type() == Variant::Type::BOOL) {
+		return bool(ret);
+	} else {
+		ERR_PRINT("Error returning from query_aabb callback: Wrong return type. Was expecting bool but instead got " + ret.get_type_name(ret.get_type()) + ".");
+		return false;
+	}
 }
 
 float Box2DWorld::UserRaycastQueryCallback::ReportFixture(b2Fixture *fixture, const b2Vec2 &point, const b2Vec2 &normal, float fraction) {
 	const int argcount = 4;
-	Variant args[argcount] = {
-		Variant(fixture->GetUserData().owner), // TODO see comment above
-		Variant(b2_to_gd(point)),
-		Variant(Vector2(normal.x, normal.y)),
-		Variant(fraction)
+	Variant arg0 = Variant(fixture->GetUserData().owner); // TODO see comment above
+	Variant arg1 = Variant(b2_to_gd(point));
+	Variant arg2 = Variant(Vector2(normal.x, normal.y));
+	Variant arg3 = Variant(fraction);
+	Variant *args[argcount] = {
+		&arg0,
+		&arg1,
+		&arg2,
+		&arg3
 	};
 	Variant ret;
 	Callable::CallError ce;
@@ -1120,5 +1130,10 @@ float Box2DWorld::UserRaycastQueryCallback::ReportFixture(b2Fixture *fixture, co
 		return false;
 	}
 
-	return float(ret);
+	if (ret.get_type() == Variant::Type::FLOAT) {
+		return float(ret);
+	} else {
+		ERR_PRINT("Error returning from raycast callback: Wrong return type. Was expecting float but instead got " + ret.get_type_name(ret.get_type()) + ".");
+		return false;
+	}
 }

--- a/scene/2d/box2d_world.cpp
+++ b/scene/2d/box2d_world.cpp
@@ -812,7 +812,9 @@ struct CastQueryWrapper {
 
 	bool QueryCallback(int32 proxyId) {
 		b2FixtureProxy *proxy = (b2FixtureProxy *)broadPhase->GetUserData(proxyId);
+
 		if (_query_should_ignore_fixture(proxy->fixture, params->is_collide_with_sensors_enabled(), params->is_collide_with_bodies_enabled(), params->get_collision_mask(), params->_get_exclude()))
+			return true;
 
 		// There could be some optimization here for cast_motion.
 		// We could compute TOI here and store the minimum fraction of motion [0, 1].

--- a/scene/2d/box2d_world.h
+++ b/scene/2d/box2d_world.h
@@ -188,7 +188,7 @@ private:
 private:
 	Vector2 gravity;
 	bool auto_step{true};
-	b2World *world;
+	b2World *world = NULL;
 
 	std::list<GodotSignalCaller> collision_callback_queue{};
 

--- a/scene/2d/box2d_world.h
+++ b/scene/2d/box2d_world.h
@@ -17,6 +17,7 @@
 #include "../../util/box2d_types_converter.h"
 
 #include <list>
+#include <unordered_set>
 
 /**
 * @author Brian Semrau
@@ -214,7 +215,7 @@ private:
 			b2Fixture *fixture = NULL;
 			b2Vec2 point;
 			b2Vec2 normal;
-			// float fraction;
+			// float fraction; // TODO maybe we'll want this
 		};
 
 		Result result;
@@ -229,6 +230,7 @@ private:
 
 	class UserAABBQueryCallback : public b2QueryCallback {
 	public:
+		std::unordered_set<const Box2DFixture *> handled_fixtures;
 		const Callable *callback = NULL;
 
 		virtual bool ReportFixture(b2Fixture *fixture) override;
@@ -236,6 +238,7 @@ private:
 
 	class UserRaycastQueryCallback : public b2RayCastCallback {
 	public:
+		std::unordered_set<const Box2DFixture *> handled_fixtures;
 		const Callable *callback = NULL;
 
 		virtual float ReportFixture(b2Fixture *fixture, const b2Vec2 &point, const b2Vec2 &normal, float fraction) override;

--- a/scene/2d/box2d_world.h
+++ b/scene/2d/box2d_world.h
@@ -222,6 +222,20 @@ private:
 		virtual float ReportFixture(b2Fixture *fixture, const b2Vec2 &point, const b2Vec2 &normal, float fraction) override;
 	};
 
+	class UserAABBQueryCallback : public b2QueryCallback {
+	public:
+		const Callable *callback = NULL;
+
+		virtual bool ReportFixture(b2Fixture *fixture) override;
+	};
+
+	class UserRaycastQueryCallback : public b2RayCastCallback {
+	public:
+		const Callable *callback = NULL;
+
+		virtual float ReportFixture(b2Fixture *fixture, const b2Vec2 &point, const b2Vec2 &normal, float fraction) override;
+	};
+
 private:
 	Vector2 gravity;
 	bool auto_step{true};
@@ -259,6 +273,9 @@ private:
 	RaycastQueryCallback ray_callback;
 	ShapeQueryCallback shape_callback;
 
+	UserAABBQueryCallback user_query_callback;
+	UserRaycastQueryCallback user_raycast_callback;
+
 	void create_b2World();
 	void destroy_b2World();
 
@@ -292,8 +309,8 @@ public:
 	Array cast_motion(const Ref<Box2DShapeQueryParameters> &p_query);
 
 	// Box2D space query API
-	//Array query_aabb(const Rect2 &p_bounds); // TODO add more parameters like Physics2DDirectSpaceState::_intersect_point
-	//Array raycast(); // Handled by Godot API
+	void query_aabb(const Rect2 &p_aabb, const Callable &p_callback);
+	void raycast(const Vector2 &p_from, const Vector2 &p_to, const Callable &p_callback);
 
 	Box2DWorld();
 	~Box2DWorld();

--- a/scene/2d/box2d_world.h
+++ b/scene/2d/box2d_world.h
@@ -4,6 +4,7 @@
 #include <core/io/resource.h>
 #include <core/object/object.h>
 #include <core/object/reference.h>
+#include <core/templates/set.h>
 #include <scene/2d/node_2d.h>
 
 #include <box2d/b2_contact.h>
@@ -91,20 +92,51 @@ struct ContactBufferManifold {
 	}
 };
 
+class Box2DWorld;
+class Box2DPhysicsBody;
+
 class Box2DShapeQueryParameters : public Reference {
 	GDCLASS(Box2DShapeQueryParameters, Reference);
 
-	Ref<Box2DShape> shape;
-	Transform2D transform;
-	//Vector2 motion; // TODO does Box2D support this?
-	//Set<Ref<Box2DPhysicsBody>> exclude; // TODO figure out how to use nodes as parameters in bound methods
-	uint32_t collision_mask;
+	friend class Box2DWorld;
 
-	// TODO a bunch of shit ugh
+	Ref<Box2DShape> shape_ref;
+	Transform2D transform = Transform2D();
+	Vector2 motion = Vector2(0, 0);
+	Set<Box2DPhysicsBody *> exclude;
+	// potential addition: exclude fixtures
+	uint32_t collision_mask = 0xFFFFFFFF; // TODO fix: b2 uses uint16
+	// TODO should we include other Box2D collision filter params?
+	bool collide_with_bodies = true; // TODO might be better named as "collide_with_solids"
+	bool collide_with_sensors = false;
+
+protected:
+	static void _bind_methods();
+
+public:
+	// TODO accessors/method binding
+	void set_shape(const RES &p_shape_ref);
+	RES get_shape() const;
+
+	void set_transform(const Transform2D &p_transform);
+	Transform2D get_transform() const;
+
+	void set_motion(const Vector2 &p_motion);
+	Vector2 get_motion() const;
+
+	void set_collision_mask(int p_collision_mask);
+	int get_collision_mask() const;
+
+	void set_collide_with_bodies(bool p_enable);
+	bool is_collide_with_bodies_enabled() const;
+
+	void set_collide_with_sensors(bool p_enable);
+	bool is_collide_with_sensors_enabled() const;
+
+	// Using ObjectID instead of RID because we don't use RIDs (comparing to Godot API)
+	void set_exclude(const Vector<int64_t> &p_exclude);
+	Vector<int64_t> get_exclude() const;
 };
-
-class Box2DWorld;
-class Box2DPhysicsBody;
 
 class Box2DWorld : public Node2D, public virtual b2DestructionListener, public virtual b2ContactFilter, public virtual b2ContactListener {
 	GDCLASS(Box2DWorld, Node2D);
@@ -113,18 +145,6 @@ class Box2DWorld : public Node2D, public virtual b2DestructionListener, public v
 	friend class Box2DJoint;
 
 private:
-	// TODO Refactor this callback garbage.
-	//      It may make sense to do this when/if shape queries are implemented.
-	//      These at least need renamed.
-	class QueryCallback : public b2QueryCallback {
-	public:
-		Vector<b2Fixture *> results;
-
-		Box2DShapeQueryParameters params;
-
-		virtual bool ReportFixture(b2Fixture *fixture) override;
-	};
-
 	class GodotSignalCaller {
 		public:
 		String signal_name{""};
@@ -138,16 +158,29 @@ private:
 			obj_a = p_obja;
 			obj_b = p_objb;
 		}
-
 	};
 
-	class IntersectPointCallback : public b2QueryCallback {
+	class ShapeQueryCallback : public b2QueryCallback {
 	public:
-		Vector<b2Fixture *> results;
+		Set<Box2DFixture *> results; // Use a set so composite fixtures don't double-count towards max_results
+
+		Ref<Box2DShapeQueryParameters> params;
+		int max_results;
+
+		virtual bool ReportFixture(b2Fixture *fixture) override;
+	};
+
+	class PointQueryCallback : public b2QueryCallback {
+	public:
+		Set<Box2DFixture *> results;
 
 		b2Vec2 point;
 		int max_results;
-		//Set<Ref<Box2DPhysicsBody> > exclude;
+		Set<Box2DPhysicsBody *> exclude;
+		uint32_t collision_mask;
+		// TODO include other b2Filter properties?
+		bool collide_with_bodies;
+		bool collide_with_sensors;
 
 		virtual bool ReportFixture(b2Fixture *fixture) override;
 	};
@@ -185,8 +218,8 @@ private:
 	/// Note: this is only called for contacts that are touching, solid, and awake.
 	virtual void PostSolve(b2Contact *contact, const b2ContactImpulse *impulse) override;
 
-	QueryCallback aabbCallback;
-	IntersectPointCallback pointCallback;
+	ShapeQueryCallback shape_callback;
+	PointQueryCallback point_callback;
 
 	void create_b2World();
 	void destroy_b2World();
@@ -196,8 +229,6 @@ protected:
 	static void _bind_methods();
 
 public:
-
-
 	enum {
 		NOTIFICATION_WORLD_STEPPED = 42300, // special int that shouldn't clobber other notifications.  See node.h
 	};
@@ -212,13 +243,18 @@ public:
 
 	//bool isLocked() const;
 
-	Array intersect_point(const Vector2 &p_point, int p_max_results = 32); //, const Vector<Ref<Box2DPhysicsBody> > &p_exclude = Vector<Ref<Box2DPhysicsBody> >() /*, uint32_t p_layers = 0*/);
-	//Array intersect_shape();
-	//Array query_aabb(const Rect2 &p_bounds); // TODO add more parameters like Physics2DDirectSpaceState::_intersect_point
-
 	//void shiftOrigin(const Vector2 &newOrigin);
 
-	// debugDraw
+	// Godot space query API
+	//Array cast_motion(const Ref<Box2DShapeQueryParameters> &p_query);
+	//Array collide_shape(const Ref<Box2DShapeQueryParameters> &p_query, int p_max_results = 32);
+	Array intersect_point(const Vector2 &p_point, int p_max_results = 32, const Vector<int64_t> &p_exclude = Vector<int64_t>(), uint32_t p_collision_mask = 0xFFFFFFFF, bool p_collide_with_bodies = true, bool p_collide_with_sensors = false);
+	//Dictionary intersect_ray(const Vector2 &p_from, const Vector2 &p_to, const Vector<int64_t> &p_exclude = Vector<int64_t>(), uint32_t p_collision_mask = 0xFFFFFFFF, bool p_collide_with_bodies = true, bool p_collide_with_sensors = false);
+	Array intersect_shape(const Ref<Box2DShapeQueryParameters> &p_query, int p_max_results = 32);
+
+	// Box2D space query API
+	//Array query_aabb(const Rect2 &p_bounds); // TODO add more parameters like Physics2DDirectSpaceState::_intersect_point
+	//Array raycast(); // Handled by Godot API
 
 	Box2DWorld();
 	~Box2DWorld();

--- a/scene/2d/box2d_world.h
+++ b/scene/2d/box2d_world.h
@@ -106,8 +106,7 @@ class Box2DShapeQueryParameters : public Reference {
 
 	Set<Box2DPhysicsBody *> exclude;
 	// potential addition: exclude fixtures
-	uint32_t collision_mask = 0xFFFFFFFF; // TODO fix: b2 uses uint16
-	// TODO should we include other Box2D collision filter params?
+	b2Filter filter; // TODO If/when we fork Box2D, filters get 32bit data
 	bool collide_with_bodies = true; // TODO might be better named as "collide_with_solids"
 	bool collide_with_sensors = false;
 
@@ -122,6 +121,9 @@ protected:
 	static void _bind_methods();
 
 public:
+	const b2Filter &_get_filter() const;
+	Set<Box2DPhysicsBody *> _get_exclude() const;
+
 	void set_shape(const RES &p_shape_ref);
 	RES get_shape() const;
 
@@ -140,8 +142,14 @@ public:
 	void set_motion_local_center(const Vector2 &p_local_center);
 	Vector2 get_motion_local_center() const;
 
+	void set_collision_layer(int p_layer);
+	int get_collision_layer() const;
+
 	void set_collision_mask(int p_collision_mask);
 	int get_collision_mask() const;
+
+	void set_group_index(int p_index);
+	int get_group_index() const;
 
 	void set_collide_with_bodies(bool p_enable);
 	bool is_collide_with_bodies_enabled() const;
@@ -152,7 +160,6 @@ public:
 	// Using ObjectIDs as int64_t so that we can bind these methods
 	void set_exclude(const Vector<int64_t> &p_exclude);
 	Vector<int64_t> get_exclude() const;
-	Set<Box2DPhysicsBody *> _get_exclude() const;
 };
 
 class Box2DWorld : public Node2D, public virtual b2DestructionListener, public virtual b2ContactFilter, public virtual b2ContactListener {
@@ -184,8 +191,7 @@ private:
 		b2Vec2 point;
 		int max_results;
 		Set<Box2DPhysicsBody *> exclude;
-		uint32_t collision_mask;
-		// TODO include other b2Filter properties?
+		b2Filter filter;
 		bool collide_with_bodies;
 		bool collide_with_sensors;
 
@@ -214,8 +220,7 @@ private:
 		Result result;
 
 		Set<Box2DPhysicsBody *> exclude;
-		uint32_t collision_mask;
-		// TODO include other b2Filter properties?
+		b2Filter filter;
 		bool collide_with_bodies;
 		bool collide_with_sensors;
 
@@ -303,8 +308,8 @@ public:
 	// Godot space query API
 	// What is collide_shape? Does this return manifold points?
 	//Array collide_shape(const Ref<Box2DShapeQueryParameters> &p_query, int p_max_results = 32);
-	Array intersect_point(const Vector2 &p_point, int p_max_results = 32, const Vector<int64_t> &p_exclude = Vector<int64_t>(), uint32_t p_collision_mask = 0xFFFFFFFF, bool p_collide_with_bodies = true, bool p_collide_with_sensors = false);
-	Dictionary intersect_ray(const Vector2 &p_from, const Vector2 &p_to, const Vector<int64_t> &p_exclude = Vector<int64_t>(), uint32_t p_collision_mask = 0xFFFFFFFF, bool p_collide_with_bodies = true, bool p_collide_with_sensors = false);
+	Array intersect_point(const Vector2 &p_point, int p_max_results = 32, const Vector<int64_t> &p_exclude = Vector<int64_t>(), uint32_t p_collision_mask = 0xFFFFFFFF, bool p_collide_with_bodies = true, bool p_collide_with_sensors = false, uint32_t p_collision_layer = 0x0, int32_t p_group_index = 0);
+	Dictionary intersect_ray(const Vector2 &p_from, const Vector2 &p_to, const Vector<int64_t> &p_exclude = Vector<int64_t>(), uint32_t p_collision_mask = 0xFFFFFFFF, bool p_collide_with_bodies = true, bool p_collide_with_sensors = false, uint32_t p_collision_layer = 0x0, int32_t p_group_index = 0);
 	Array intersect_shape(const Ref<Box2DShapeQueryParameters> &p_query, int p_max_results = 32);
 	Array cast_motion(const Ref<Box2DShapeQueryParameters> &p_query);
 

--- a/scene/resources/box2d_shapes.cpp
+++ b/scene/resources/box2d_shapes.cpp
@@ -70,7 +70,14 @@ bool Box2DShape::is_composite_shape() const {
 }
 
 const Vector<const b2Shape *> Box2DShape::get_shapes() const {
-	ERR_FAIL_V(Vector<const b2Shape *>());
+	if (is_composite_shape()) {
+		CRASH_NOW_MSG("Box2DShape::get_shapes must be overridden by all composite shapes.");
+		ERR_FAIL_V(Vector<const b2Shape *>());
+	} else {
+		Vector<const b2Shape *> vec;
+		vec.append(get_shape());
+		return vec;
+	}
 }
 
 bool Box2DShape::_edit_is_selected_on_click(const Point2 &p_point, double p_tolerance) const {

--- a/scene/resources/box2d_shapes.h
+++ b/scene/resources/box2d_shapes.h
@@ -21,16 +21,14 @@ class Box2DShape : public Resource {
 	GDCLASS(Box2DShape, Resource);
 	OBJ_SAVE_TYPE(Box2DShape);
 
-	friend class Box2DFixture;
-
-	virtual bool is_composite_shape() const;
-	virtual const Vector<const b2Shape *> get_shapes() const;
-	virtual const b2Shape *get_shape() const = 0;
-
 protected:
 	static void _bind_methods();
 
 public:
+	virtual bool is_composite_shape() const;
+	virtual const Vector<const b2Shape *> get_shapes() const;
+	virtual const b2Shape *get_shape() const = 0;
+
 	virtual bool _edit_is_selected_on_click(const Point2 &p_point, double p_tolerance) const;
 
 	virtual void draw(const RID &p_to_rid, const Color &p_color) = 0;
@@ -44,12 +42,12 @@ class Box2DCircleShape : public Box2DShape {
 
 	b2CircleShape circleShape;
 
-	virtual const b2Shape *get_shape() const override { return &circleShape; }
-
 protected:
 	static void _bind_methods();
 
 public:
+	virtual const b2Shape *get_shape() const override { return &circleShape; }
+
 	void set_radius(real_t p_radius);
 	real_t get_radius() const;
 
@@ -66,12 +64,12 @@ class Box2DRectShape : public Box2DShape {
 	real_t height;
 	// TODO replace width/height with a Vector2 for consistency
 
-	virtual const b2Shape *get_shape() const override { return &shape; }
-
 protected:
 	static void _bind_methods();
 
 public:
+	virtual const b2Shape *get_shape() const override { return &shape; }
+
 	void set_size(const Vector2 &p_size);
 	Vector2 get_size() const;
 
@@ -91,12 +89,12 @@ class Box2DSegmentShape : public Box2DShape {
 
 	b2EdgeShape shape;
 
-	virtual const b2Shape *get_shape() const override { return &shape; }
-
 protected:
 	static void _bind_methods();
 
 public:
+	virtual const b2Shape *get_shape() const override { return &shape; }
+
 	void set_a(const Vector2 &p_a);
 	Vector2 get_a() const;
 
@@ -154,11 +152,11 @@ private:
 protected:
 	static void _bind_methods();
 
+public:
 	virtual bool is_composite_shape() const override;
 	virtual const Vector<const b2Shape *> get_shapes() const override;
 	virtual const b2Shape *get_shape() const override { return chain_shape; }
 
-public:
 	bool _edit_is_selected_on_click(const Point2 &p_point, double p_tolerance) const override;
 
 	void set_point_cloud(const Vector<Vector2> &p_points);
@@ -190,17 +188,17 @@ class Box2DCapsuleShape : public Box2DShape {
 	real_t radius;
 	real_t height;
 
-	virtual bool is_composite_shape() const override { return true; };
-	virtual const Vector<const b2Shape *> get_shapes() const override;
-	virtual const b2Shape *get_shape() const override {
-		CRASH_NOW();
-		ERR_FAIL_V(&bottomCircleShape);
-	}
-
 protected:
 	static void _bind_methods();
 
 public:
+	virtual bool is_composite_shape() const override { return true; };
+	virtual const Vector<const b2Shape *> get_shapes() const override;
+	virtual const b2Shape *get_shape() const override {
+		CRASH_NOW_MSG("You can never call get_shape on a composite capsule.");
+		ERR_FAIL_V(&bottomCircleShape);
+	}
+
 	void set_height(real_t p_height);
 	real_t get_height() const;
 


### PR DESCRIPTION
This resolves #9 

This implements:
- `cast_motion` with extra motion parameters because Box2D is cool like that
- `intersect_point`
- `intersect_ray`
- `intersect_shape`

And the functional equivalent of b2World's:
- `query_aabb`
- `raycast`

It should be noted that `PhysicsDirectSpaceState2D.collision_layer` is named improperly. It actually represents the collision_mask. This error is not carried over to this implementation, so carryover user code will need to switch to the correct property when setting collision parameter properties.

This implementation is not thoroughly tested. I've confirmed that `intersect_point` and `cast_motion` (with only motion set, not rotation) work. I know the callbacks in query_aabb work. A lot of the code is pretty similar and I'm lazy so I expect it all to work.