### PR TITLE
Refactor Box2DPhysicsBody to enable future implementation of Box2DArea

### DIFF
--- a/b2include/b2_user_settings.h
+++ b/b2include/b2_user_settings.h
@@ -27,7 +27,7 @@
 
 // User data
 
-class Box2DPhysicsBody;
+class Box2DCollisionObject;
 class Box2DFixture;
 class Box2DJoint;
 
@@ -35,7 +35,8 @@ struct B2_API b2BodyUserData {
 	b2BodyUserData() :
 			owner(NULL) {}
 
-	Box2DPhysicsBody *owner;
+	Box2DCollisionObject *owner;
+	//bool is_area;
 };
 
 struct B2_API b2FixtureUserData {

--- a/register_types.cpp
+++ b/register_types.cpp
@@ -3,6 +3,8 @@
 #include "editor/box2d_joint_editor_plugin.h"
 #include "editor/box2d_polygon_editor_plugin.h"
 #include "editor/box2d_shape_editor_plugin.h"
+//#include "scene/2d/box2d_area.h"
+#include "scene/2d/box2d_collision_object.h"
 #include "scene/2d/box2d_fixtures.h"
 #include "scene/2d/box2d_joints.h"
 #include "scene/2d/box2d_physics_body.h"
@@ -19,7 +21,9 @@ void register_godot_box2d_types() {
 
 	ClassDB::register_class<Box2DShapeQueryParameters>();
 	ClassDB::register_class<Box2DWorld>();
+	ClassDB::register_virtual_class<Box2DCollisionObject>();
 	ClassDB::register_class<Box2DPhysicsBody>();
+	//ClassDB::register_class<Box2DArea>();
 	ClassDB::register_class<Box2DFixture>();
 	ClassDB::register_virtual_class<Box2DShape>();
 	ClassDB::register_class<Box2DCircleShape>();

--- a/scene/2d/box2d_collision_object.cpp
+++ b/scene/2d/box2d_collision_object.cpp
@@ -2,6 +2,7 @@
 
 #include <core/config/engine.h>
 
+#include "box2d_world.h"
 #include "box2d_fixtures.h"
 #include "box2d_joints.h"
 

--- a/scene/2d/box2d_collision_object.cpp
+++ b/scene/2d/box2d_collision_object.cpp
@@ -1,0 +1,353 @@
+#include "box2d_collision_object.h"
+
+#include <core/config/engine.h>
+
+#include "box2d_fixtures.h"
+#include "box2d_joints.h"
+
+#include <vector>
+
+/**
+* @author Brian Semrau
+*/
+
+void Box2DCollisionObject::on_parent_created(Node *) {
+	//if (create_b2Body()) {
+	//	print_line("body created");
+	//}
+	WARN_PRINT("BODY CREATED IN CALLBACK");
+}
+
+bool Box2DCollisionObject::create_b2Body() {
+	if (world_node && !body) {
+		ERR_FAIL_COND_V(!world_node->world, false);
+
+		// Create body
+		bodyDef.position = gd_to_b2(get_box2dworld_transform().get_origin());
+		bodyDef.angle = get_box2dworld_transform().get_rotation();
+
+		body = world_node->world->CreateBody(&bodyDef);
+		body->GetUserData().owner = this;
+
+		on_b2Body_created();
+
+		return true;
+	}
+	return false;
+}
+
+bool Box2DCollisionObject::destroy_b2Body() {
+	if (body) {
+		ERR_FAIL_COND_V(!world_node, false);
+		ERR_FAIL_COND_V(!world_node->world, false);
+
+		// Destroy body
+		world_node->world->DestroyBody(body);
+		body = NULL;
+
+		// b2Fixture destruction is handled by Box2D
+		// b2Joint destruction is handled by Box2D
+
+		on_b2Body_destroyed();
+
+		return true;
+	}
+	return false;
+}
+
+void Box2DCollisionObject::update_filterdata() {
+	if (body) {
+		b2Fixture *fixture = body->GetFixtureList();
+		while (fixture) {
+			if (!fixture->GetUserData().owner->get_override_body_collision()) {
+				fixture->SetFilterData(filterDef);
+			}
+			fixture = fixture->GetNext();
+		}
+	}
+}
+
+Transform2D Box2DCollisionObject::get_box2dworld_transform() {
+	std::vector<Transform2D> transforms{};
+	transforms.push_back(get_transform());
+	Node* parent = get_parent();
+	while(parent) {
+		if(parent == world_node) {
+			break;
+		}
+		CanvasItem* cv = Object::cast_to<CanvasItem>(parent);
+		if(cv) {
+			transforms.push_back(cv->get_transform());
+		}
+		parent = parent->get_parent();
+	}
+
+	Transform2D returned{};
+	while(transforms.size() > 0) {
+		returned = returned * transforms.back();
+		transforms.pop_back();
+	}
+
+	return returned;
+}
+
+void Box2DCollisionObject::set_box2dworld_transform(const Transform2D &p_transform) {
+	std::vector<Transform2D> transforms{};
+	transforms.push_back(p_transform);
+	Node* parent = get_parent();
+	while(parent) {
+		if(parent == world_node) {
+			break;
+		}
+		CanvasItem* cv = Object::cast_to<CanvasItem>(parent);
+		if(cv) {
+			transforms.push_back(cv->get_transform().affine_inverse());
+		}
+		parent = parent->get_parent();
+	}
+
+	Transform2D target_xform{};
+	while(transforms.size() > 0) {
+		target_xform = target_xform * transforms.back();
+		transforms.pop_back();
+	}
+	set_transform(target_xform);
+}
+
+void Box2DCollisionObject::_set_contact_monitor(bool p_enabled) {
+	if (p_enabled == _is_contact_monitor_enabled()) {
+		return;
+	}
+
+	if (!p_enabled) {
+		memdelete(contact_monitor);
+		contact_monitor = NULL;
+	} else {
+		contact_monitor = memnew(ContactMonitor);
+		//contact_monitor->locked = false;
+
+		if (body) {
+			world_node->flag_rescan_contacts_monitored = true;
+		}
+	}
+}
+
+bool Box2DCollisionObject::_is_contact_monitor_enabled() const {
+	return contact_monitor != NULL;
+}
+
+void Box2DCollisionObject::_notification(int p_what) {
+	// TODO finalize implementation to imitate behavior from RigidBody2D and Kinematic (static too?)
+	switch (p_what) {
+		case NOTIFICATION_PREDELETE: {
+			destroy_b2Body();
+		} break;
+
+		case NOTIFICATION_ENTER_TREE: {
+			// Find the Box2DWorld
+			Node *_ancestor = get_parent();
+			Box2DWorld *new_world = NULL;
+			while (_ancestor && !new_world) {
+				new_world = Object::cast_to<Box2DWorld>(_ancestor);
+				_ancestor = _ancestor->get_parent();
+			}
+
+			// If new parent, recreate body
+			if (new_world != world_node) {
+				// Destroy b2Body
+				if (world_node) {
+					destroy_b2Body();
+					if (world_node) {
+						world_node->body_owners.erase(this);
+					}
+				}
+				world_node = new_world;
+				// Create b2Body
+				if (world_node) {
+					world_node->body_owners.insert(this);
+
+					if (world_node->world) {
+						create_b2Body();
+					}
+				}
+			}
+
+			if (Engine::get_singleton()->is_editor_hint() || get_tree()->is_debugging_collisions_hint()) {
+				set_process_internal(true);
+			}
+		} break;
+
+		case NOTIFICATION_EXIT_TREE: {
+			// Don't destroy body. It could be exiting/entering.
+			// Body should be destroyed in destructor if node is being freed.
+
+			// TODO What do we do if it exits the tree, the ref is kept (in a script), and it's never destroyed?
+			//      Exiting w/o reentering should destroy body.
+			//      This applies to Box2DFixture and Box2DJoint as well.
+
+			set_process_internal(false);
+		} break;
+
+		case NOTIFICATION_LOCAL_TRANSFORM_CHANGED: {
+			// Send new transform to physics
+			Transform2D new_xform = get_box2dworld_transform();
+
+			bodyDef.position = gd_to_b2(new_xform.get_origin());
+			bodyDef.angle = new_xform.get_rotation();
+
+			if (body) {
+				body->SetTransform(gd_to_b2(new_xform.get_origin()), new_xform.get_rotation());
+			}
+		} break;
+
+		case NOTIFICATION_INTERNAL_PROCESS: {
+			// Do nothing
+		} break;
+
+		case NOTIFICATION_DRAW: {
+			if (!Engine::get_singleton()->is_editor_hint() && !get_tree()->is_debugging_collisions_hint()) {
+				break;
+			}
+
+			// Probably do nothing here
+			// TODO remove this case
+		}
+	}
+}
+
+void Box2DCollisionObject::_bind_methods() {
+	ClassDB::bind_method(D_METHOD("set_enabled", "enabled"), &Box2DCollisionObject::set_enabled);
+	ClassDB::bind_method(D_METHOD("is_enabled"), &Box2DCollisionObject::is_enabled);
+	ClassDB::bind_method(D_METHOD("set_collision_layer", "collision_layer"), &Box2DCollisionObject::set_collision_layer);
+	ClassDB::bind_method(D_METHOD("get_collision_layer"), &Box2DCollisionObject::get_collision_layer);
+	ClassDB::bind_method(D_METHOD("set_collision_mask", "collision_mask"), &Box2DCollisionObject::set_collision_mask);
+	ClassDB::bind_method(D_METHOD("get_collision_mask"), &Box2DCollisionObject::get_collision_mask);
+	ClassDB::bind_method(D_METHOD("set_group_index", "group_index"), &Box2DCollisionObject::set_group_index);
+	ClassDB::bind_method(D_METHOD("get_group_index"), &Box2DCollisionObject::get_group_index);
+
+	ClassDB::bind_method(D_METHOD("set_filter_data", "collision_layer", "collision_mask", "group_index"), &Box2DCollisionObject::set_filter_data);
+	
+	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "enabled"), "set_enabled", "is_enabled");
+	ADD_GROUP("Collision", "");
+	ADD_PROPERTY(PropertyInfo(Variant::INT, "collision_layer", PROPERTY_HINT_LAYERS_2D_PHYSICS), "set_collision_layer", "get_collision_layer");
+	ADD_PROPERTY(PropertyInfo(Variant::INT, "collision_mask", PROPERTY_HINT_LAYERS_2D_PHYSICS), "set_collision_mask", "get_collision_mask");
+	ADD_PROPERTY(PropertyInfo(Variant::INT, "group_index"), "set_group_index", "get_group_index");
+
+	ADD_SIGNAL(MethodInfo("enabled_state_changed"));
+}
+
+String Box2DCollisionObject::get_configuration_warning() const {
+	String warning = Node2D::get_configuration_warning();
+
+	Node *_ancestor = get_parent();
+	Box2DWorld *new_world = NULL;
+	while (_ancestor && !new_world) {
+		new_world = Object::cast_to<Box2DWorld>(_ancestor);
+		_ancestor = _ancestor->get_parent();
+	}
+
+	if (!new_world) {
+		if (warning != String()) {
+			warning += "\n\n";
+		}
+		warning += TTR("Box2DCollisionObject only serves to provide bodies to a Box2DWorld node. Please only use it under the hierarchy of Box2DWorld.");
+	}
+
+	bool has_fixture_child = false;
+	for (int i = 0; i < get_child_count(); i++) {
+		if (Object::cast_to<Box2DFixture>(get_child(i))) {
+			has_fixture_child = true;
+			break;
+		}
+	}
+	if (!has_fixture_child) {
+		if (warning != String()) {
+			warning += "\n\n";
+		}
+		warning += TTR("This node has no fixture, so it can't collide or interact with other objects.\nConsider adding a Box2DFixture subtype as a child to define its shape.");
+	}
+
+	return warning;
+}
+
+void Box2DCollisionObject::set_enabled(bool p_enabled) {
+	if (body)
+		body->SetEnabled(p_enabled);
+	bodyDef.enabled = p_enabled;
+}
+
+bool Box2DCollisionObject::is_enabled() const {
+	return bodyDef.enabled;
+}
+
+void Box2DCollisionObject::set_collision_layer(uint16_t p_layer) {
+	if (filterDef.categoryBits != p_layer) {
+		filterDef.categoryBits = p_layer;
+		update_filterdata();
+	}
+}
+
+uint16_t Box2DCollisionObject::get_collision_layer() const {
+	return filterDef.categoryBits;
+}
+
+void Box2DCollisionObject::set_collision_mask(uint16_t p_mask) {
+	if (filterDef.maskBits != p_mask) {
+		filterDef.maskBits = p_mask;
+		update_filterdata();
+	}
+}
+
+uint16_t Box2DCollisionObject::get_collision_mask() const {
+	return filterDef.maskBits;
+}
+
+void Box2DCollisionObject::set_group_index(int16_t p_group_index) {
+	if (filterDef.groupIndex != p_group_index) {
+		filterDef.groupIndex = p_group_index;
+		update_filterdata();
+	}
+}
+
+int16_t Box2DCollisionObject::get_group_index() const {
+	return filterDef.groupIndex;
+}
+
+void Box2DCollisionObject::set_filter_data(uint16_t p_layer, uint16_t p_mask, int16 p_group_index) {
+	if (filterDef.categoryBits != p_layer || filterDef.maskBits != p_mask || filterDef.groupIndex != p_group_index) {
+		filterDef.categoryBits = p_layer;
+		filterDef.maskBits = p_mask;
+		filterDef.groupIndex = p_group_index;
+		update_filterdata();
+	}
+}
+
+Array Box2DCollisionObject::get_colliding_bodies() const {
+	ERR_FAIL_COND_V(!contact_monitor, Array());
+	Array ret;
+
+	List<ObjectID> keys;
+	contact_monitor->entered_objects.get_key_list(&keys);
+	for (int i = 0; i < keys.size(); i++) {
+		Object *node = ObjectDB::get_instance(keys[i]);
+		if (node && Object::cast_to<Box2DCollisionObject>(node)) {
+			ret.append(node);
+		}
+	}
+
+	return ret;
+}
+
+Box2DCollisionObject::Box2DCollisionObject() {
+	filterDef.maskBits = 0x0001;
+
+	set_physics_process_internal(true);
+	set_notify_local_transform(true);
+}
+
+Box2DCollisionObject::~Box2DCollisionObject() {
+	if (body && world_node) {
+		WARN_PRINT("b2Body is being deleted in destructor, not NOTIFICATION_PREDELETE.");
+		destroy_b2Body();
+	} // else Box2D has/will clean up body
+}

--- a/scene/2d/box2d_collision_object.h
+++ b/scene/2d/box2d_collision_object.h
@@ -12,11 +12,13 @@
 #include <box2d/b2_world.h>
 
 #include "../../util/box2d_types_converter.h"
-#include "box2d_world.h"
 
 /**
 * @author Brian Semrau
 */
+
+class Box2DWorld;
+struct Box2DContactPoint;
 
 class Box2DCollisionObject : public Node2D {
 	GDCLASS(Box2DCollisionObject, Node2D);
@@ -67,6 +69,11 @@ protected:
 
 	void _set_contact_monitor(bool p_enabled);
 	bool _is_contact_monitor_enabled() const;
+
+	virtual void _on_object_entered(Box2DCollisionObject *p_object) = 0;
+	virtual void _on_object_exited(Box2DCollisionObject *p_object) = 0;
+	virtual void _on_fixture_entered(Box2DFixture *p_fixture) = 0;
+	virtual void _on_fixture_exited(Box2DFixture *p_fixture) = 0;
 
 protected:
 	void _notification(int p_what);

--- a/scene/2d/box2d_collision_object.h
+++ b/scene/2d/box2d_collision_object.h
@@ -1,0 +1,104 @@
+#ifndef BOX2D_COLLISION_OBJECT_H
+#define BOX2D_COLLISION_OBJECT_H
+
+#include <core/io/resource.h>
+#include <core/object/object.h>
+#include <core/object/reference.h>
+#include <core/templates/vset.h>
+#include <scene/2d/node_2d.h>
+
+#include <box2d/b2_body.h>
+#include <box2d/b2_fixture.h>
+#include <box2d/b2_world.h>
+
+#include "../../util/box2d_types_converter.h"
+#include "box2d_world.h"
+
+/**
+* @author Brian Semrau
+*/
+
+class Box2DCollisionObject : public Node2D {
+	GDCLASS(Box2DCollisionObject, Node2D);
+
+	friend class Box2DWorld;
+	friend class Box2DFixture;
+	friend class Box2DJoint;
+
+	b2Filter filterDef;
+
+	b2Body *body = NULL;
+
+	Box2DWorld *world_node = NULL;
+
+	// Moving to and from world transform
+	void set_box2dworld_transform(const Transform2D &p_transform);
+	Transform2D get_box2dworld_transform();
+
+	void on_parent_created(Node *);
+
+	bool create_b2Body();
+	bool destroy_b2Body();
+
+	void update_filterdata();
+
+protected:
+	b2BodyDef bodyDef;
+
+	struct ContactMonitor {
+		// bool locked; // TODO when physics moved to separate thread
+		VSet<Box2DContactPoint> contacts;
+
+		// TODO when adding area functionality, this list can be used to apply area effects
+		// All the bodies/fixtures currently in contact with this body.
+		// The int value stores the number of b2Fixtures currently in contact.
+		// When the counter transitions from 0->1 or 1->0, body_entered/exited is emitted.
+		HashMap<ObjectID, int> entered_objects;
+	};
+
+	ContactMonitor *contact_monitor = NULL;
+	int max_contacts_reported = 0;
+
+	inline Box2DWorld *_get_world_node() const { return world_node; };
+	inline b2Body *_get_b2Body() const { return body; }
+
+	virtual void on_b2Body_created(){};
+	virtual void on_b2Body_destroyed(){};
+
+	void _set_contact_monitor(bool p_enabled);
+	bool _is_contact_monitor_enabled() const;
+
+protected:
+	void _notification(int p_what);
+	static void _bind_methods();
+
+public:
+	virtual String get_configuration_warning() const override;
+
+	void set_enabled(bool p_enabled);
+	bool is_enabled() const;
+
+	void set_collision_layer(uint16_t p_layer);
+	uint16_t get_collision_layer() const;
+
+	void set_collision_mask(uint16_t p_mask);
+	uint16_t get_collision_mask() const;
+
+	void set_group_index(int16_t p_group_index);
+	int16_t get_group_index() const;
+
+	void set_filter_data(uint16_t p_layer, uint16_t p_mask, int16 p_group_index);
+
+	//void set_contact_monitor(bool p_enabled);
+	//bool is_contact_monitor_enabled() const;
+
+	//void set_max_contacts_reported(int p_amount);
+	//int get_max_contacts_reported() const;
+
+	Array get_colliding_bodies() const; // Function exists for Godot feature congruency
+
+	Box2DCollisionObject();
+	~Box2DCollisionObject();
+};
+
+#endif // BOX2D_COLLISION_OBJECT_H

--- a/scene/2d/box2d_fixtures.cpp
+++ b/scene/2d/box2d_fixtures.cpp
@@ -2,6 +2,7 @@
 
 #include <core/config/engine.h>
 
+#include "box2d_collision_object.h"
 #include "box2d_physics_body.h"
 
 /**
@@ -145,14 +146,16 @@ void Box2DFixture::_notification(int p_what) {
 			// If new parent, recreate fixture
 			if (owner_node != new_body) {
 				if (owner_node) {
-					owner_node->disconnect("sleeping_state_changed", Callable(this, "update"));
+					if (owner_node->has_signal("sleeping_state_changed"))
+						owner_node->disconnect("sleeping_state_changed", Callable(this, "update"));
 					owner_node->disconnect("enabled_state_changed", Callable(this, "update"));
 				}
 				destroy_b2();
 
 				owner_node = new_body;
 
-				owner_node->connect("sleeping_state_changed", Callable(this, "update"));
+				if (owner_node->has_signal("sleeping_state_changed"))
+					owner_node->connect("sleeping_state_changed", Callable(this, "update"));
 				owner_node->connect("enabled_state_changed", Callable(this, "update"));
 
 				if (owner_node && owner_node->body && shape.is_valid()) {
@@ -298,11 +301,11 @@ bool Box2DFixture::_edit_is_selected_on_click(const Point2 &p_point, double p_to
 String Box2DFixture::get_configuration_warning() const {
 	String warning = Node2D::get_configuration_warning();
 
-	if (!Object::cast_to<Box2DPhysicsBody>(get_parent())) {
+	if (!Object::cast_to<Box2DCollisionObject>(get_parent())) {
 		if (warning != String()) {
 			warning += "\n\n";
 		}
-		warning += TTR("Box2DFixture subtypes only serve to provide collision fixtures to a Box2DPhysicsBody node. Please use it as a child of Box2DPhysicsBody to give it collision.");
+		warning += TTR("Box2DFixture subtypes only serve to provide collision fixtures to a Box2DCollisionObject node. Please use it as a child of Box2DPhysicsBody or Box2DArea to give it collision.");
 	}
 
 	return warning;

--- a/scene/2d/box2d_fixtures.h
+++ b/scene/2d/box2d_fixtures.h
@@ -59,6 +59,8 @@ protected:
 	static void _bind_methods();
 
 public:
+	inline const Box2DCollisionObject *_get_owner_node() const { return owner_node; }
+
 	virtual bool _edit_is_selected_on_click(const Point2 &p_point, double p_tolerance) const override;
 
 	virtual String get_configuration_warning() const override;

--- a/scene/2d/box2d_fixtures.h
+++ b/scene/2d/box2d_fixtures.h
@@ -14,7 +14,7 @@
 
 #include "../../util/box2d_types_converter.h"
 #include "../resources/box2d_shapes.h"
-#include "box2d_physics_body.h"
+#include "box2d_collision_object.h"
 #include "box2d_world.h"
 
 /**
@@ -37,7 +37,7 @@ class Box2DFixture : public Node2D {
 	VSet<Box2DFixture *> filtering_me;
 	// TODO might fixtures need to filter other whole bodies?
 
-	Box2DPhysicsBody *body_node = NULL;
+	Box2DCollisionObject *owner_node = NULL;
 
 	Vector<b2Fixture *> fixtures;
 
@@ -59,9 +59,7 @@ protected:
 	static void _bind_methods();
 
 public:
-#ifdef TOOLS_ENABLED
 	virtual bool _edit_is_selected_on_click(const Point2 &p_point, double p_tolerance) const override;
-#endif
 
 	virtual String get_configuration_warning() const override;
 

--- a/scene/2d/box2d_joints.cpp
+++ b/scene/2d/box2d_joints.cpp
@@ -231,11 +231,14 @@ void Box2DJoint::_notification(int p_what) {
 			// Will attempt to recreate in POST_ENTER_TREE.
 			if (new_world != world_node) {
 				if (world_node) {
-					world_node->joints.erase(this);
+					world_node->joint_owners.erase(this);
 				}
 				destroy_b2Joint();
 
 				world_node = new_world;
+				if (world_node) {
+					world_node->joint_owners.insert(this);
+				}
 			}
 
 			if (Engine::get_singleton()->is_editor_hint() || get_tree()->is_debugging_collisions_hint()) {

--- a/scene/2d/box2d_physics_body.cpp
+++ b/scene/2d/box2d_physics_body.cpp
@@ -1,6 +1,7 @@
 #include "box2d_physics_body.h"
 
 #include <core/config/engine.h>
+#include <scene/scene_string_names.h>
 
 #include "box2d_fixtures.h"
 #include "box2d_joints.h"
@@ -90,6 +91,34 @@ void Box2DPhysicsBody::sync_state() {
 	//if (contact_monitoring) {
 	//	world_node->world.contac
 	//}
+}
+
+void Box2DPhysicsBody::_on_object_entered(Box2DCollisionObject *p_object) {
+	const Box2DPhysicsBody *body = dynamic_cast<const Box2DPhysicsBody *>(p_object);
+	if (body) {
+		emit_signal(SceneStringNames::get_singleton()->body_entered, body);
+	}
+}
+
+void Box2DPhysicsBody::_on_object_exited(Box2DCollisionObject *p_object) {
+	const Box2DPhysicsBody *body = dynamic_cast<const Box2DPhysicsBody *>(p_object);
+	if (body) {
+		emit_signal(SceneStringNames::get_singleton()->body_exited, body);
+	}
+}
+
+void Box2DPhysicsBody::_on_fixture_entered(Box2DFixture *p_fixture) {
+	const Box2DPhysicsBody *body = dynamic_cast<const Box2DPhysicsBody *>(p_fixture->_get_owner_node());
+	if (body) {
+		emit_signal("body_fixture_entered", p_fixture);
+	}
+}
+
+void Box2DPhysicsBody::_on_fixture_exited(Box2DFixture *p_fixture) {
+	const Box2DPhysicsBody *body = dynamic_cast<const Box2DPhysicsBody *>(p_fixture->_get_owner_node());
+	if (body) {
+		emit_signal("body_fixture_exited", p_fixture);
+	}
 }
 
 void Box2DPhysicsBody::_notification(int p_what) {
@@ -263,11 +292,11 @@ void Box2DPhysicsBody::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "custom_mass", PROPERTY_HINT_EXP_RANGE, "0.01,65535,0.01"), "set_custom_mass", "get_custom_mass");
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "custom_inertia", PROPERTY_HINT_EXP_RANGE, "0.01,65535,0.01"), "set_custom_inertia", "get_custom_inertia");
 	ADD_PROPERTY(PropertyInfo(Variant::VECTOR2, "custom_center_of_mass"), "set_custom_center_of_mass", "get_custom_center_of_mass");
-	
-	ADD_SIGNAL(MethodInfo("body_fixture_entered", PropertyInfo(Variant::OBJECT, "fixture", PROPERTY_HINT_RESOURCE_TYPE, "Node"), PropertyInfo(Variant::OBJECT, "local_fixture", PROPERTY_HINT_RESOURCE_TYPE, "Node")));
-	ADD_SIGNAL(MethodInfo("body_fixture_exited", PropertyInfo(Variant::OBJECT, "fixture", PROPERTY_HINT_RESOURCE_TYPE, "Node"), PropertyInfo(Variant::OBJECT, "local_fixture", PROPERTY_HINT_RESOURCE_TYPE, "Node")));
-	ADD_SIGNAL(MethodInfo("body_entered", PropertyInfo(Variant::OBJECT, "body", PROPERTY_HINT_RESOURCE_TYPE, "Node")));
-	ADD_SIGNAL(MethodInfo("body_exited", PropertyInfo(Variant::OBJECT, "body", PROPERTY_HINT_RESOURCE_TYPE, "Node")));
+
+	ADD_SIGNAL(MethodInfo("body_fixture_entered", PropertyInfo(Variant::OBJECT, "fixture", PROPERTY_HINT_RESOURCE_TYPE, "Box2DFixture"), PropertyInfo(Variant::OBJECT, "local_fixture", PROPERTY_HINT_RESOURCE_TYPE, "Box2DFixture")));
+	ADD_SIGNAL(MethodInfo("body_fixture_exited", PropertyInfo(Variant::OBJECT, "fixture", PROPERTY_HINT_RESOURCE_TYPE, "Box2DFixture"), PropertyInfo(Variant::OBJECT, "local_fixture", PROPERTY_HINT_RESOURCE_TYPE, "Box2DFixture")));
+	ADD_SIGNAL(MethodInfo("body_entered", PropertyInfo(Variant::OBJECT, "body", PROPERTY_HINT_RESOURCE_TYPE, "Box2DPhysicsBody")));
+	ADD_SIGNAL(MethodInfo("body_exited", PropertyInfo(Variant::OBJECT, "body", PROPERTY_HINT_RESOURCE_TYPE, "Box2DPhysicsBody")));
 	ADD_SIGNAL(MethodInfo("sleeping_state_changed"));
 
 	BIND_ENUM_CONSTANT(MODE_RIGID);
@@ -353,7 +382,6 @@ void Box2DPhysicsBody::set_custom_mass(const real_t p_mass) {
 }
 
 real_t Box2DPhysicsBody::get_custom_mass() const {
-
 	return massDataDef.mass;
 }
 

--- a/scene/2d/box2d_physics_body.h
+++ b/scene/2d/box2d_physics_body.h
@@ -1,9 +1,9 @@
 #ifndef BOX2D_PHYSICS_BODY_H
 #define BOX2D_PHYSICS_BODY_H
 
+#include <core/io/resource.h>
 #include <core/object/object.h>
 #include <core/object/reference.h>
-#include <core/io/resource.h>
 #include <core/templates/vset.h>
 #include <scene/2d/node_2d.h>
 
@@ -12,8 +12,9 @@
 #include <box2d/b2_world.h>
 
 #include "../../util/box2d_types_converter.h"
-#include "box2d_world.h"
+
 #include "box2d_collision_object.h"
+#include "box2d_world.h"
 
 /**
 * @author Brian Semrau
@@ -58,6 +59,11 @@ private:
 	void update_mass(bool p_calc_reset = true);
 
 	void sync_state();
+
+	virtual void _on_object_entered(Box2DCollisionObject *p_object) override;
+	virtual void _on_object_exited(Box2DCollisionObject *p_object) override;
+	virtual void _on_fixture_entered(Box2DFixture *p_fixture) override;
+	virtual void _on_fixture_exited(Box2DFixture *p_fixture) override;
 
 protected:
 	virtual void on_b2Body_created() override;
@@ -112,7 +118,7 @@ public:
 
 	void set_fixed_rotation(bool p_fixed);
 	bool is_fixed_rotation() const;
-	
+
 	Array get_collision_exceptions();
 	void add_collision_exception_with(Node *p_node);
 	void remove_collision_exception_with(Node *p_node);

--- a/scene/2d/box2d_world.cpp
+++ b/scene/2d/box2d_world.cpp
@@ -305,9 +305,7 @@ void Box2DWorld::BeginContact(b2Contact *contact) {
 		++(*body_count_ptr);
 
 		if (*body_count_ptr == 1) {
-			// TODO replace with callable_mp to Box2DCollisionObject virtual func `object_entered`
-			// This func can then call signals "body/area_entered"
-			collision_callback_queue.push_back(GodotSignalCaller("body_entered", body_a, body_b, nullptr));
+			object_entered_queue.enqueue(body_a, body_b);
 		}
 
 		int *fix_count_ptr = body_a->contact_monitor->entered_objects.getptr(fnode_b->get_instance_id());
@@ -317,7 +315,7 @@ void Box2DWorld::BeginContact(b2Contact *contact) {
 		++(*fix_count_ptr);
 
 		if (*fix_count_ptr == 1) {
-			collision_callback_queue.push_back(GodotSignalCaller("body_fixture_entered", body_a, fnode_b, fnode_a));
+			fixture_entered_queue.enqueue(body_a, fnode_b);
 		}
 	}
 	if (monitoringB) {
@@ -328,7 +326,7 @@ void Box2DWorld::BeginContact(b2Contact *contact) {
 		++(*body_count_ptr);
 
 		if (*body_count_ptr == 1) {
-			collision_callback_queue.push_back(GodotSignalCaller("body_entered", body_b, body_a, nullptr));
+			object_entered_queue.enqueue(body_b, body_a);
 		}
 
 		int *fix_count_ptr = body_b->contact_monitor->entered_objects.getptr(fnode_a->get_instance_id());
@@ -338,7 +336,7 @@ void Box2DWorld::BeginContact(b2Contact *contact) {
 		++(*fix_count_ptr);
 
 		if (*fix_count_ptr == 1) {
-			collision_callback_queue.push_back(GodotSignalCaller("body_fixture_entered", body_b, fnode_a, fnode_b));
+			fixture_entered_queue.enqueue(body_b, fnode_a);
 		}
 	}
 }
@@ -359,7 +357,7 @@ void Box2DWorld::EndContact(b2Contact *contact) {
 
 		if ((*body_count_ptr) == 0) {
 			body_a->contact_monitor->entered_objects.erase(body_b->get_instance_id());
-			collision_callback_queue.push_back(GodotSignalCaller("body_exited", body_a, body_b, nullptr));
+			object_exited_queue.enqueue(body_a, body_b);
 		}
 
 		int *fix_count_ptr = body_a->contact_monitor->entered_objects.getptr(fnode_b->get_instance_id());
@@ -367,7 +365,7 @@ void Box2DWorld::EndContact(b2Contact *contact) {
 
 		if ((*fix_count_ptr) == 0) {
 			body_a->contact_monitor->entered_objects.erase(fnode_b->get_instance_id());
-			collision_callback_queue.push_back(GodotSignalCaller("body_fixture_exited", body_a, fnode_b, fnode_a));
+			fixture_exited_queue.enqueue(body_a, fnode_b);
 		}
 	}
 	if (monitoringB) {
@@ -376,7 +374,7 @@ void Box2DWorld::EndContact(b2Contact *contact) {
 
 		if ((*body_count_ptr) == 0) {
 			body_b->contact_monitor->entered_objects.erase(body_a->get_instance_id());
-			collision_callback_queue.push_back(GodotSignalCaller("body_exited", body_b, body_a, nullptr));
+			object_exited_queue.enqueue(body_b, body_a);
 		}
 
 		int *fix_count_ptr = body_b->contact_monitor->entered_objects.getptr(fnode_a->get_instance_id());
@@ -384,7 +382,7 @@ void Box2DWorld::EndContact(b2Contact *contact) {
 
 		if ((*fix_count_ptr) == 0) {
 			body_b->contact_monitor->entered_objects.erase(fnode_a->get_instance_id());
-			collision_callback_queue.push_back(GodotSignalCaller("body_fixture_exited", body_b, fnode_a, fnode_b));
+			fixture_exited_queue.enqueue(body_b, fnode_a);
 		}
 	}
 
@@ -640,12 +638,6 @@ void Box2DWorld::_bind_methods() {
 }
 
 void Box2DWorld::step(float p_step) {
-	//print_line(("step: " + std::to_string(p_step)
-	//		+ ", gravity: ("
-	//		+ std::to_string(world->GetGravity().x) + ", "
-	//		+ std::to_string(world->GetGravity().y) + ")")
-	//	.c_str());
-
 	// Reset contact "solves" counter to 0
 	const uint64_t *k = NULL;
 	while ((k = contact_buffer.next(k))) {
@@ -658,17 +650,11 @@ void Box2DWorld::step(float p_step) {
 	world->Step(p_step, 8, 8);
 	flag_rescan_contacts_monitored = false;
 
-	// Pump callbacks
-	while(!collision_callback_queue.empty()) {
-		GodotSignalCaller sig = collision_callback_queue.front();
-		if(sig.obj_b) {
-			sig.obj_emitter->emit_signal(sig.signal_name, sig.obj_a, sig.obj_b);
-		}
-		else {
-			sig.obj_emitter->emit_signal(sig.signal_name, sig.obj_a);
-		}
-		collision_callback_queue.pop_front();
-	}
+	// Body/shape inout callbacks
+	object_entered_queue.call_and_clear();
+	object_exited_queue.call_and_clear();
+	fixture_entered_queue.call_and_clear();
+	fixture_exited_queue.call_and_clear();
 
 	// Notify our bodies in this world
 	propagate_notification(NOTIFICATION_WORLD_STEPPED);

--- a/scene/2d/box2d_world.cpp
+++ b/scene/2d/box2d_world.cpp
@@ -6,6 +6,7 @@
 #include <box2d/b2_collision.h>
 #include <box2d/b2_time_of_impact.h>
 
+#include "box2d_collision_object.h"
 #include "box2d_fixtures.h"
 #include "box2d_joints.h"
 
@@ -223,10 +224,12 @@ bool Box2DWorld::ShouldCollide(b2Fixture *fixtureA, b2Fixture *fixtureB) {
 	}
 
 	// Check for body exclusions
-	Box2DPhysicsBody *const &bodyA = ownerA->body_node;
-	Box2DPhysicsBody *const &bodyB = ownerB->body_node;
-	if ((ownerA->accept_body_collision_exceptions && bodyA->filtered.has(bodyB)) || (ownerB->accept_body_collision_exceptions && bodyB->filtered.has(bodyA))) {
-		return false;
+	Box2DPhysicsBody *const &bodyA = dynamic_cast<Box2DPhysicsBody *>(ownerA->owner_node);
+	Box2DPhysicsBody *const &bodyB = dynamic_cast<Box2DPhysicsBody *>(ownerB->owner_node);
+	if (bodyA && bodyB) {
+		if ((ownerA->accept_body_collision_exceptions && bodyA->filtered.has(bodyB)) || (ownerB->accept_body_collision_exceptions && bodyB->filtered.has(bodyA))) {
+			return false;
+		}
 	}
 
 	// TODO should we bother to let bodies exclude fixtures?
@@ -240,11 +243,11 @@ inline void Box2DWorld::try_buffer_contact(b2Contact *contact, int i) {
 
 	Box2DFixture *fnode_a = contact->GetFixtureA()->GetUserData().owner;
 	Box2DFixture *fnode_b = contact->GetFixtureB()->GetUserData().owner;
-	Box2DPhysicsBody *body_a = fnode_a->body_node;
-	Box2DPhysicsBody *body_b = fnode_b->body_node;
+	Box2DCollisionObject *body_a = fnode_a->owner_node;
+	Box2DCollisionObject *body_b = fnode_b->owner_node;
 
-	const bool monitoringA = fnode_a->body_node->is_contact_monitor_enabled();
-	const bool monitoringB = fnode_b->body_node->is_contact_monitor_enabled();
+	const bool monitoringA = fnode_a->owner_node->_is_contact_monitor_enabled();
+	const bool monitoringB = fnode_b->owner_node->_is_contact_monitor_enabled();
 
 	// Only buffer contacts that are being monitored, if contact monitor report count isn't exceeded
 
@@ -272,11 +275,11 @@ inline void Box2DWorld::try_buffer_contact(b2Contact *contact, int i) {
 
 		// Buffer again into monitoring node
 		if (hasCapacityA) {
-			auto contacts = &fnode_a->body_node->contact_monitor->contacts;
+			auto contacts = &fnode_a->owner_node->contact_monitor->contacts;
 			contacts->insert(c);
 		}
 		if (hasCapacityB) {
-			auto contacts = &fnode_b->body_node->contact_monitor->contacts;
+			auto contacts = &fnode_b->owner_node->contact_monitor->contacts;
 			contacts->insert(c);
 		}
 	}
@@ -285,11 +288,11 @@ inline void Box2DWorld::try_buffer_contact(b2Contact *contact, int i) {
 void Box2DWorld::BeginContact(b2Contact *contact) {
 	Box2DFixture *fnode_a = contact->GetFixtureA()->GetUserData().owner;
 	Box2DFixture *fnode_b = contact->GetFixtureB()->GetUserData().owner;
-	Box2DPhysicsBody *body_a = fnode_a->body_node;
-	Box2DPhysicsBody *body_b = fnode_b->body_node;
+	Box2DCollisionObject *body_a = fnode_a->owner_node;
+	Box2DCollisionObject *body_b = fnode_b->owner_node;
 
-	const bool monitoringA = fnode_a->body_node->is_contact_monitor_enabled();
-	const bool monitoringB = fnode_b->body_node->is_contact_monitor_enabled();
+	const bool monitoringA = fnode_a->owner_node->_is_contact_monitor_enabled();
+	const bool monitoringB = fnode_b->owner_node->_is_contact_monitor_enabled();
 
 	// Deliver signals to bodies with monitoring enabled
 	// Only emit body_entered once per body. Begin/EndContact are called for each b2Fixture.
@@ -302,6 +305,8 @@ void Box2DWorld::BeginContact(b2Contact *contact) {
 		++(*body_count_ptr);
 
 		if (*body_count_ptr == 1) {
+			// TODO replace with callable_mp to Box2DCollisionObject virtual func `object_entered`
+			// This func can then call signals "body/area_entered"
 			collision_callback_queue.push_back(GodotSignalCaller("body_entered", body_a, body_b, nullptr));
 		}
 
@@ -341,11 +346,11 @@ void Box2DWorld::BeginContact(b2Contact *contact) {
 void Box2DWorld::EndContact(b2Contact *contact) {
 	Box2DFixture *fnode_a = contact->GetFixtureA()->GetUserData().owner;
 	Box2DFixture *fnode_b = contact->GetFixtureB()->GetUserData().owner;
-	Box2DPhysicsBody *body_a = fnode_a->body_node;
-	Box2DPhysicsBody *body_b = fnode_b->body_node;
+	Box2DCollisionObject *body_a = fnode_a->owner_node;
+	Box2DCollisionObject *body_b = fnode_b->owner_node;
 
-	const bool monitoringA = fnode_a->body_node->is_contact_monitor_enabled();
-	const bool monitoringB = fnode_b->body_node->is_contact_monitor_enabled();
+	const bool monitoringA = fnode_a->owner_node->_is_contact_monitor_enabled();
+	const bool monitoringB = fnode_b->owner_node->_is_contact_monitor_enabled();
 
 	// Deliver signals to bodies with contact monitoring enabled
 	if (monitoringA) {
@@ -390,13 +395,13 @@ void Box2DWorld::EndContact(b2Contact *contact) {
 		for (int i = 0; i < buffer_manifold->count; ++i) {
 			Box2DContactPoint *c_ptr = &buffer_manifold->points[i];
 
-			if (c_ptr->fixture_a->body_node->is_contact_monitor_enabled()) {
+			if (c_ptr->fixture_a->owner_node->_is_contact_monitor_enabled()) {
 				// TODO lock/unlock
-				c_ptr->fixture_a->body_node->contact_monitor->contacts.erase(*c_ptr);
+				c_ptr->fixture_a->owner_node->contact_monitor->contacts.erase(*c_ptr);
 			}
-			if (c_ptr->fixture_b->body_node->is_contact_monitor_enabled()) {
+			if (c_ptr->fixture_b->owner_node->_is_contact_monitor_enabled()) {
 				// TODO lock/unlock
-				c_ptr->fixture_b->body_node->contact_monitor->contacts.erase(*c_ptr);
+				c_ptr->fixture_b->owner_node->contact_monitor->contacts.erase(*c_ptr);
 			}
 		}
 
@@ -430,13 +435,13 @@ void Box2DWorld::PreSolve(b2Contact *contact, const b2Manifold *oldManifold) {
 			if (buffer_manifold && i < buffer_manifold->count) {
 				Box2DContactPoint *c_ptr = &buffer_manifold->points[i];
 
-				if (c_ptr->fixture_a->body_node->is_contact_monitor_enabled()) {
+				if (c_ptr->fixture_a->owner_node->_is_contact_monitor_enabled()) {
 					// TODO lock/unlock
-					c_ptr->fixture_a->body_node->contact_monitor->contacts.erase(*c_ptr);
+					c_ptr->fixture_a->owner_node->contact_monitor->contacts.erase(*c_ptr);
 				}
-				if (c_ptr->fixture_b->body_node->is_contact_monitor_enabled()) {
+				if (c_ptr->fixture_b->owner_node->_is_contact_monitor_enabled()) {
 					// TODO lock/unlock
-					c_ptr->fixture_b->body_node->contact_monitor->contacts.erase(*c_ptr);
+					c_ptr->fixture_b->owner_node->contact_monitor->contacts.erase(*c_ptr);
 				}
 
 				buffer_manifold->remove(i);
@@ -486,8 +491,8 @@ void Box2DWorld::PostSolve(b2Contact *contact, const b2ContactImpulse *impulse) 
 	const Box2DFixture *fnode_a = contact->GetFixtureA()->GetUserData().owner;
 	const Box2DFixture *fnode_b = contact->GetFixtureB()->GetUserData().owner;
 
-	const bool monitoringA = fnode_a->body_node->is_contact_monitor_enabled();
-	const bool monitoringB = fnode_b->body_node->is_contact_monitor_enabled();
+	const bool monitoringA = fnode_a->owner_node->_is_contact_monitor_enabled();
+	const bool monitoringB = fnode_b->owner_node->_is_contact_monitor_enabled();
 	if (monitoringA || monitoringB) {
 		b2WorldManifold worldManifold;
 		contact->GetWorldManifold(&worldManifold);
@@ -506,7 +511,7 @@ void Box2DWorld::PostSolve(b2Contact *contact, const b2ContactImpulse *impulse) 
 				// Update contacts buffered in listening nodes
 				if (monitoringA) {
 					//fnode_a->body_node->contact_monitor.locked = true; TODO
-					auto contacts = &fnode_a->body_node->contact_monitor->contacts;
+					auto contacts = &fnode_a->owner_node->contact_monitor->contacts;
 					int idx = contacts->find(*c_ptr);
 					if (idx >= 0)
 						(*contacts)[idx] = (*c_ptr);
@@ -517,7 +522,7 @@ void Box2DWorld::PostSolve(b2Contact *contact, const b2ContactImpulse *impulse) 
 					Box2DContactPoint cB = c_ptr->flipped_a_b();
 
 					//fnode_b->body_node->contact_monitor.locked = true; TODO
-					auto contacts = &fnode_b->body_node->contact_monitor->contacts;
+					auto contacts = &fnode_b->owner_node->contact_monitor->contacts;
 					int idx = contacts->find(cB);
 					if (idx >= 0)
 						(*contacts)[idx] = (cB);
@@ -536,12 +541,12 @@ void Box2DWorld::create_b2World() {
 		world->SetContactFilter(this);
 		world->SetContactListener(this);
 
-		Set<Box2DPhysicsBody *>::Element *body = bodies.front();
+		Set<Box2DCollisionObject *>::Element *body = body_owners.front();
 		while (body) {
 			body->get()->on_parent_created(this);
 			body = body->next();
 		}
-		Set<Box2DJoint *>::Element *joint = joints.front();
+		Set<Box2DJoint *>::Element *joint = joint_owners.front();
 		while (joint) {
 			joint->get()->on_parent_created(this);
 			joint = joint->next();
@@ -719,10 +724,12 @@ Array Box2DWorld::intersect_point(const Vector2 &p_point, int p_max_results, con
 		Box2DFixture *fixture = element->get();
 
 		Dictionary d;
-		d["body"] = fixture->body_node;
+		d["body"] = fixture->owner_node;
 		d["fixture"] = fixture;
 		// TODO do we really need to return a dict, or can we just return an
 		//      array of Box2DFixture objects and let the user get data from just that?
+
+		// TODO don't return a dictionary... The "body" element is just too strange after the refactor
 
 		arr[i] = d;
 		++i;
@@ -806,7 +813,7 @@ Array Box2DWorld::intersect_shape(const Ref<Box2DShapeQueryParameters> &p_query,
 		Box2DFixture *fixture = element->get();
 
 		Dictionary d;
-		d["body"] = fixture->body_node;
+		d["body"] = fixture->owner_node;
 		d["fixture"] = fixture;
 
 		arr[i] = d;
@@ -836,7 +843,7 @@ inline bool _query_should_ignore_fixture(b2Fixture *fixture, const bool collide_
 		return true;
 
 	// Check exclusion
-	if (exclude.find(fixture->GetBody()->GetUserData().owner) > 0)
+	if (exclude.find(dynamic_cast<Box2DPhysicsBody *>(fixture->GetBody()->GetUserData().owner)) > 0)
 		return true;
 
 	// This fixture should not be filtered

--- a/scene/2d/box2d_world.h
+++ b/scene/2d/box2d_world.h
@@ -95,6 +95,7 @@ struct ContactBufferManifold {
 };
 
 class Box2DWorld;
+class Box2DCollisionObject;
 class Box2DPhysicsBody;
 
 class Box2DShapeQueryParameters : public Reference {
@@ -166,7 +167,7 @@ public:
 class Box2DWorld : public Node2D, public virtual b2DestructionListener, public virtual b2ContactFilter, public virtual b2ContactListener {
 	GDCLASS(Box2DWorld, Node2D);
 
-	friend class Box2DPhysicsBody;
+	friend class Box2DCollisionObject;
 	friend class Box2DJoint;
 
 private:
@@ -251,8 +252,8 @@ private:
 
 	std::list<GodotSignalCaller> collision_callback_queue{};
 
-	Set<Box2DPhysicsBody *> bodies;
-	Set<Box2DJoint *> joints;
+	Set<Box2DCollisionObject *> body_owners;
+	Set<Box2DJoint *> joint_owners;
 
 	virtual void SayGoodbye(b2Joint *joint) override;
 	virtual void SayGoodbye(b2Fixture *fixture) override;


### PR DESCRIPTION
This move b2Body ownership to a new abstract class, `Box2DCollisionObject`. Exposed properties are very similar to CollisionObject2D in Godot physics. This allows creation of new node types that depend on b2Body (specifically Box2DArea 🙂) without duplication of hundreds of lines of code, improving future maintainability.

This should break absolutely nothing - all existing functionality should be identical. However, downstream changes may have merge conflicts. I'm willing to resolve conflicts in this PR if anything else can be merged before this.

Relevant to #10