### PR TITLE
Update to work with latest Godot 4.0

### DIFF
--- a/SCsub
+++ b/SCsub
@@ -90,7 +90,6 @@ env_thirdparty.add_source_files(env.modules_sources, thirdparty_sources)
 module_subdirs = [
     "",
     "util/",
-    "editor/",
     "scene/2d/",
     "scene/resources/",
 ]
@@ -98,4 +97,5 @@ module_subdirs = [
 for f in module_subdirs:
     env_godot_box2d.add_source_files(env.modules_sources, f + "*.cpp")
 
-
+if env.editor_build:
+    env_godot_box2d.add_source_files(env.modules_sources, "editor/*.cpp")

--- a/SCsub
+++ b/SCsub
@@ -7,7 +7,7 @@ env_godot_box2d = env_modules.Clone()
 
 # Thirdparty source files
 
-thirdparty_dir = "#modules/godot_box2d/thirdparty/box2d/"
+thirdparty_dir = "thirdparty/box2d/"
 
 box2d_src = [
     "collision/b2_broad_phase.cpp",
@@ -73,7 +73,7 @@ box2d_include = [
 
 thirdparty_sources = [thirdparty_dir + "src/" + file for file in box2d_src]
 thirdparty_include = [thirdparty_dir + file for file in box2d_include]
-thirdparty_include.append(["#modules/godot_box2d/b2include/"])
+thirdparty_include.append(["b2include/"])
 
 # add Box2D includes to our module
 env_godot_box2d.Prepend(CPPPATH=thirdparty_include)

--- a/editor/box2d_joint_editor_plugin.cpp
+++ b/editor/box2d_joint_editor_plugin.cpp
@@ -1,5 +1,8 @@
 #include "box2d_joint_editor_plugin.h"
 
+#include <scene/gui/separator.h>
+#include <scene/gui/button.h>
+#include <editor/editor_node.h>
 #include <editor/plugins/canvas_item_editor_plugin.h>
 
 #include "../scene/2d/box2d_joints.h"
@@ -42,11 +45,11 @@ void Box2DJointEditor::disable_anchor_modes(bool p_disable, String p_reason) {
 	button_anchor_global->set_disabled(p_disable);
 
 	if (p_disable) {
-		button_anchor_local->set_tooltip(p_reason);
-		button_anchor_global->set_tooltip(p_reason);
+		button_anchor_local->set_tooltip_text(p_reason);
+		button_anchor_global->set_tooltip_text(p_reason);
 	} else {
-		button_anchor_local->set_tooltip(TTR("Move anchors with joint")); // TODO translation file?
-		button_anchor_global->set_tooltip(TTR("Anchors stick to their body"));
+		button_anchor_local->set_tooltip_text(TTR("Move anchors with joint")); // TODO translation file?
+		button_anchor_global->set_tooltip_text(TTR("Anchors stick to their body"));
 	}
 }
 
@@ -521,7 +524,7 @@ bool Box2DJointEditor::forward_canvas_gui_input(const Ref<InputEvent> &p_event) 
 	if (mb.is_valid()) {
 		Vector2 gpoint = mb->get_position();
 
-		if (mb->get_button_index() == MouseButton::MOUSE_BUTTON_LEFT) {
+		if (mb->get_button_index() == MouseButton::LEFT) {
 			if (mb->is_pressed()) {
 				for (int i = 0; i < handles.size(); i++) {
 					if (xform.xform(handles[i]).distance_to(gpoint - handle_offsets[i]) < 8) {
@@ -952,22 +955,21 @@ void Box2DJointEditor::edit(Node *p_node) {
 void Box2DJointEditor::_bind_methods() {
 }
 
-Box2DJointEditor::Box2DJointEditor(EditorNode *p_editor) :
-		editor(p_editor),
-		undo_redo(EditorNode::get_undo_redo()) {
+Box2DJointEditor::Box2DJointEditor() :
+		undo_redo(EditorUndoRedoManager::get_singleton()) {
 
 	add_child(memnew(VSeparator));
 
 	button_anchor_local = memnew(Button);
 	button_anchor_local->set_flat(true);
 	add_child(button_anchor_local);
-	button_anchor_local->connect("pressed", callable_mp(this, &Box2DJointEditor::_menu_option), varray(static_cast<int>(AnchorMode::MODE_ANCHORS_LOCAL)));
+	button_anchor_local->connect("pressed", callable_mp(this, &Box2DJointEditor::_menu_option).bind(static_cast<int>(AnchorMode::MODE_ANCHORS_LOCAL)));
 	button_anchor_local->set_toggle_mode(true);
 
 	button_anchor_global = memnew(Button);
 	button_anchor_global->set_flat(true);
 	add_child(button_anchor_global);
-	button_anchor_global->connect("pressed", callable_mp(this, &Box2DJointEditor::_menu_option), varray(static_cast<int>(AnchorMode::MODE_ANCHORS_STICKY)));
+	button_anchor_global->connect("pressed", callable_mp(this, &Box2DJointEditor::_menu_option).bind(static_cast<int>(AnchorMode::MODE_ANCHORS_STICKY)));
 	button_anchor_global->set_toggle_mode(true);
 
 	//add_child(memnew(VSeparator));
@@ -992,10 +994,8 @@ void Box2DJointEditorPlugin::make_visible(bool p_visible) {
 	}
 }
 
-Box2DJointEditorPlugin::Box2DJointEditorPlugin(EditorNode *p_editor) {
-	editor = p_editor;
-
-	box2d_joint_editor = memnew(Box2DJointEditor(p_editor));
+Box2DJointEditorPlugin::Box2DJointEditorPlugin() {
+	box2d_joint_editor = memnew(Box2DJointEditor);
 	//p_editor->get_gui_base()->add_child(box2d_joint_editor);
 	CanvasItemEditor::get_singleton()->add_control_to_menu_panel(box2d_joint_editor);
 	box2d_joint_editor->hide();

--- a/editor/box2d_joint_editor_plugin.h
+++ b/editor/box2d_joint_editor_plugin.h
@@ -1,8 +1,9 @@
 #ifndef BOX2D_JOINT_EDITOR_PLUGIN_H
 #define BOX2D_JOINT_EDITOR_PLUGIN_H
 
-#include <editor/editor_node.h>
+#include <scene/gui/box_container.h>
 #include <editor/editor_plugin.h>
+#include <editor/editor_undo_redo_manager.h>
 
 #include "../scene/resources/box2d_shapes.h"
 
@@ -32,8 +33,7 @@ class Box2DJointEditor : public HBoxContainer {
 		INVALID_JOINT
 	};
 
-	EditorNode *editor;
-	UndoRedo *undo_redo;
+	EditorUndoRedoManager *undo_redo;
 	CanvasItemEditor *canvas_item_editor = NULL;
 	Box2DJoint *node = NULL;
 
@@ -76,26 +76,25 @@ public:
 	void forward_canvas_draw_over_viewport(Control *p_overlay);
 	void edit(Node *p_node);
 
-	Box2DJointEditor(EditorNode *p_editor);
+	Box2DJointEditor();
 };
 
 class Box2DJointEditorPlugin : public EditorPlugin {
 	GDCLASS(Box2DJointEditorPlugin, EditorPlugin);
 
 	Box2DJointEditor *box2d_joint_editor;
-	EditorNode *editor;
 
 public:
-	virtual bool forward_canvas_gui_input(const Ref<InputEvent> &p_event) { return box2d_joint_editor->forward_canvas_gui_input(p_event); }
-	virtual void forward_canvas_draw_over_viewport(Control *p_overlay) { box2d_joint_editor->forward_canvas_draw_over_viewport(p_overlay); }
+	virtual bool forward_canvas_gui_input(const Ref<InputEvent> &p_event) override { return box2d_joint_editor->forward_canvas_gui_input(p_event); }
+	virtual void forward_canvas_draw_over_viewport(Control *p_overlay) override { box2d_joint_editor->forward_canvas_draw_over_viewport(p_overlay); }
 
-	virtual String get_name() const { return "Box2DJoint"; }
-	bool has_main_screen() const { return false; }
-	virtual void edit(Object *p_obj);
-	virtual bool handles(Object *p_obj) const;
-	virtual void make_visible(bool p_visible);
+	virtual String get_name() const override { return "Box2DJoint"; }
+	bool has_main_screen() const override { return false; }
+	virtual void edit(Object *p_obj) override;
+	virtual bool handles(Object *p_obj) const override;
+	virtual void make_visible(bool p_visible) override;
 
-	Box2DJointEditorPlugin(EditorNode *p_editor);
+	Box2DJointEditorPlugin();
 	~Box2DJointEditorPlugin();
 };
 

--- a/editor/box2d_polygon_editor_plugin.cpp
+++ b/editor/box2d_polygon_editor_plugin.cpp
@@ -34,7 +34,7 @@ void Box2DPolygonEditor::_set_node(Node *p_polygon) {
 
 bool Box2DPolygonEditor::_is_line() const {
 	if (node->get_shape().is_valid()) {
-		Box2DPolygonShape *poly = dynamic_cast<Box2DPolygonShape *>(*node->get_shape());
+		Box2DPolygonShape *poly = Object::cast_to<Box2DPolygonShape>(*node->get_shape());
 		if (poly) {
 			return poly->get_build_mode() == Box2DPolygonShape::BUILD_OPEN_SEGMENTS;
 		}
@@ -44,7 +44,7 @@ bool Box2DPolygonEditor::_is_line() const {
 
 Variant Box2DPolygonEditor::_get_polygon(int p_idx) const {
 	if (node->get_shape().is_valid()) {
-		Box2DPolygonShape *poly = dynamic_cast<Box2DPolygonShape *>(*node->get_shape());
+		Box2DPolygonShape *poly = Object::cast_to<Box2DPolygonShape>(*node->get_shape());
 		if (poly) {
 			return poly->get_points();
 		}
@@ -54,7 +54,7 @@ Variant Box2DPolygonEditor::_get_polygon(int p_idx) const {
 
 void Box2DPolygonEditor::_set_polygon(int p_idx, const Variant &p_polygon) const {
 	if (node->get_shape().is_valid()) {
-		Box2DPolygonShape *poly = dynamic_cast<Box2DPolygonShape *>(*node->get_shape());
+		Box2DPolygonShape *poly = Object::cast_to<Box2DPolygonShape>(*node->get_shape());
 		if (poly) {
 			poly->set_points(p_polygon);
 		}

--- a/editor/box2d_polygon_editor_plugin.cpp
+++ b/editor/box2d_polygon_editor_plugin.cpp
@@ -1,5 +1,7 @@
 #include "box2d_polygon_editor_plugin.h"
 
+#include <editor/editor_node.h>
+
 #include "../scene/2d/box2d_fixtures.h"
 
 /**
@@ -7,7 +9,7 @@
 */
 
 void Box2DPolygonEditor::_shape_type_changed() {
-	editor->edit_current();
+	EditorNode::get_singleton()->edit_current();
 }
 
 void Box2DPolygonEditor::_bind_methods() {
@@ -20,13 +22,13 @@ Node2D *Box2DPolygonEditor::_get_node() const {
 
 void Box2DPolygonEditor::_set_node(Node *p_polygon) {
 	if (node) {
-		node->disconnect("_shape_type_changed", Callable(this, "_shape_type_changed"));
+		node->disconnect("_shape_type_changed", callable_mp(this, &Box2DPolygonEditor::_shape_type_changed));
 	}
 
 	node = Object::cast_to<Box2DFixture>(p_polygon);
 
 	if (node) {
-		node->connect("_shape_type_changed", Callable(this, "_shape_type_changed"), Vector<Variant>(), CONNECT_DEFERRED);
+		node->connect("_shape_type_changed", callable_mp(this, &Box2DPolygonEditor::_shape_type_changed), CONNECT_DEFERRED);
 	}
 }
 
@@ -64,9 +66,8 @@ void Box2DPolygonEditor::_action_set_polygon(int p_idx, const Variant &p_previou
 	undo_redo->add_undo_method(*node->get_shape(), "set_points", p_previous);
 }
 
-Box2DPolygonEditor::Box2DPolygonEditor(EditorNode *p_editor) :
-		AbstractPolygon2DEditor(p_editor) {
-	editor = p_editor;
+Box2DPolygonEditor::Box2DPolygonEditor() {
+	undo_redo = EditorUndoRedoManager::get_singleton();
 }
 
 bool Box2DPolygonEditorPlugin::handles(Object *p_object) const {
@@ -74,5 +75,5 @@ bool Box2DPolygonEditorPlugin::handles(Object *p_object) const {
 	return node && node->get_shape().is_valid() && node->get_shape()->is_class("Box2DPolygonShape");
 }
 
-Box2DPolygonEditorPlugin::Box2DPolygonEditorPlugin(EditorNode *p_node) :
-		AbstractPolygon2DEditorPlugin(p_node, memnew(Box2DPolygonEditor(p_node)), "Box2DPolygonShape") {}
+Box2DPolygonEditorPlugin::Box2DPolygonEditorPlugin() :
+		AbstractPolygon2DEditorPlugin(memnew(Box2DPolygonEditor), "Box2DPolygonShape") {}

--- a/editor/box2d_polygon_editor_plugin.h
+++ b/editor/box2d_polygon_editor_plugin.h
@@ -1,6 +1,7 @@
 #ifndef BOX2D_POLYGON_EDITOR_PLUGIN_H
 #define BOX2D_POLYGON_EDITOR_PLUGIN_H
 
+#include <editor/editor_undo_redo_manager.h>
 #include <editor/plugins/abstract_polygon_2d_editor.h>
 
 #include "../scene/resources/box2d_shapes.h"
@@ -12,7 +13,7 @@
 class Box2DPolygonEditor : public AbstractPolygon2DEditor {
 	GDCLASS(Box2DPolygonEditor, AbstractPolygon2DEditor);
 
-	EditorNode *editor;
+	EditorUndoRedoManager *undo_redo;
 
 	Box2DFixture *node = NULL;
 	Box2DPolygonShape *shape = NULL;
@@ -32,7 +33,7 @@ protected:
 	virtual void _action_set_polygon(int p_idx, const Variant &p_previous, const Variant &p_polygon) override;
 
 public:
-	Box2DPolygonEditor(EditorNode *p_editor);
+	Box2DPolygonEditor();
 };
 
 class Box2DPolygonEditorPlugin : public AbstractPolygon2DEditorPlugin {
@@ -41,7 +42,7 @@ class Box2DPolygonEditorPlugin : public AbstractPolygon2DEditorPlugin {
 public:
 	virtual bool handles(Object *p_object) const override;
 
-	Box2DPolygonEditorPlugin(EditorNode *p_node);
+	Box2DPolygonEditorPlugin();
 };
 
 #endif // BOX2D_POLYGON_EDITOR_PLUGIN_H

--- a/editor/box2d_shape_editor_plugin.h
+++ b/editor/box2d_shape_editor_plugin.h
@@ -1,7 +1,6 @@
 #ifndef BOX2D_SHAPE_EDITOR_PLUGIN_H
 #define BOX2D_SHAPE_EDITOR_PLUGIN_H
 
-#include <editor/editor_node.h>
 #include <editor/editor_plugin.h>
 
 #include "../scene/resources/box2d_shapes.h"
@@ -27,8 +26,7 @@ class Box2DShapeEditor : public Control {
 		CAPSULE_SHAPE,
 	};
 
-	EditorNode *editor;
-	UndoRedo *undo_redo;
+	EditorUndoRedoManager *undo_redo;
 	CanvasItemEditor *canvas_item_editor = NULL;
 	Box2DFixture *node = NULL;
 
@@ -56,26 +54,25 @@ public:
 	void forward_canvas_draw_over_viewport(Control *p_overlay);
 	void edit(Node *p_node);
 
-	Box2DShapeEditor(EditorNode *p_editor);
+	Box2DShapeEditor();
 };
 
 class Box2DShapeEditorPlugin : public EditorPlugin {
 	GDCLASS(Box2DShapeEditorPlugin, EditorPlugin);
 
 	Box2DShapeEditor *box2d_shape_editor;
-	EditorNode *editor;
 
 public:
-	virtual bool forward_canvas_gui_input(const Ref<InputEvent> &p_event) { return box2d_shape_editor->forward_canvas_gui_input(p_event); }
-	virtual void forward_canvas_draw_over_viewport(Control *p_overlay) { box2d_shape_editor->forward_canvas_draw_over_viewport(p_overlay); }
+	virtual bool forward_canvas_gui_input(const Ref<InputEvent> &p_event) override { return box2d_shape_editor->forward_canvas_gui_input(p_event); }
+	virtual void forward_canvas_draw_over_viewport(Control *p_overlay) override { box2d_shape_editor->forward_canvas_draw_over_viewport(p_overlay); }
 
-	virtual String get_name() const { return "Box2DShape"; }
-	bool has_main_screen() const { return false; }
-	virtual void edit(Object *p_obj);
-	virtual bool handles(Object *p_obj) const;
-	virtual void make_visible(bool visible);
+	virtual String get_name() const override { return "Box2DShape"; }
+	bool has_main_screen() const override { return false; }
+	virtual void edit(Object *p_obj) override;
+	virtual bool handles(Object *p_obj) const override;
+	virtual void make_visible(bool visible) override;
 
-	Box2DShapeEditorPlugin(EditorNode *p_editor);
+	Box2DShapeEditorPlugin();
 	~Box2DShapeEditorPlugin();
 };
 

--- a/register_types.cpp
+++ b/register_types.cpp
@@ -1,8 +1,5 @@
 #include "register_types.h"
 
-#include "editor/box2d_joint_editor_plugin.h"
-#include "editor/box2d_polygon_editor_plugin.h"
-#include "editor/box2d_shape_editor_plugin.h"
 #include "scene/2d/box2d_area.h"
 #include "scene/2d/box2d_collision_object.h"
 #include "scene/2d/box2d_fixtures.h"
@@ -10,46 +7,54 @@
 #include "scene/2d/box2d_physics_body.h"
 #include "scene/2d/box2d_world.h"
 #include "scene/resources/box2d_shapes.h"
+#ifdef TOOLS_ENABLED
+#include "editor/box2d_joint_editor_plugin.h"
+#include "editor/box2d_polygon_editor_plugin.h"
+#include "editor/box2d_shape_editor_plugin.h"
+#endif
 
 /**
 * @author Brian Semrau
 */
 
-void register_godot_box2d_types() {
-	GLOBAL_DEF("physics/2d/box2d_conversion_factor", 50.0f);
-	ProjectSettings::get_singleton()->set_custom_property_info("physics/2d/box2d_conversion_factor", PropertyInfo(Variant::FLOAT, "physics/2d/box2d_conversion_factor"));
+void initialize_godot_box2d_module(ModuleInitializationLevel p_level) {
+	if (p_level == MODULE_INITIALIZATION_LEVEL_SCENE) {
+		GLOBAL_DEF("physics/2d/box2d_conversion_factor", 50.0f);
+		ProjectSettings::get_singleton()->set_custom_property_info(PropertyInfo(Variant::FLOAT, "physics/2d/box2d_conversion_factor"));
 
-	ClassDB::register_class<Box2DShapeQueryParameters>();
-	ClassDB::register_class<Box2DWorld>();
+		ClassDB::register_class<Box2DShapeQueryParameters>();
+		ClassDB::register_class<Box2DWorld>();
 
-	ClassDB::register_virtual_class<Box2DCollisionObject>();
-	ClassDB::register_class<Box2DPhysicsTestMotionResult>();
-	ClassDB::register_class<Box2DPhysicsBody>();
-	ClassDB::register_class<Box2DKinematicCollision>();
-	ClassDB::register_class<Box2DArea>();
+		ClassDB::register_abstract_class<Box2DCollisionObject>();
+		ClassDB::register_class<Box2DPhysicsTestMotionResult>();
+		ClassDB::register_class<Box2DPhysicsBody>();
+		ClassDB::register_class<Box2DKinematicCollision>();
+		ClassDB::register_class<Box2DArea>();
 
-	ClassDB::register_class<Box2DFixture>();
+		ClassDB::register_class<Box2DFixture>();
 
-	ClassDB::register_virtual_class<Box2DShape>();
-	ClassDB::register_class<Box2DCircleShape>();
-	ClassDB::register_class<Box2DRectShape>();
-	ClassDB::register_class<Box2DSegmentShape>();
-	ClassDB::register_class<Box2DPolygonShape>();
-	ClassDB::register_class<Box2DCapsuleShape>();
+		ClassDB::register_abstract_class<Box2DShape>();
+		ClassDB::register_class<Box2DCircleShape>();
+		ClassDB::register_class<Box2DRectShape>();
+		ClassDB::register_class<Box2DSegmentShape>();
+		ClassDB::register_class<Box2DPolygonShape>();
+		ClassDB::register_class<Box2DCapsuleShape>();
 
-	ClassDB::register_virtual_class<Box2DJoint>();
-	ClassDB::register_class<Box2DRevoluteJoint>();
-	ClassDB::register_class<Box2DPrismaticJoint>();
-	ClassDB::register_class<Box2DDistanceJoint>();
-	ClassDB::register_class<Box2DWeldJoint>();
-	// TODO more joints
-
+		ClassDB::register_abstract_class<Box2DJoint>();
+		ClassDB::register_class<Box2DRevoluteJoint>();
+		ClassDB::register_class<Box2DPrismaticJoint>();
+		ClassDB::register_class<Box2DDistanceJoint>();
+		ClassDB::register_class<Box2DWeldJoint>();
+		// TODO more joints
+	}
 #ifdef TOOLS_ENABLED
-	EditorPlugins::add_by_type<Box2DPolygonEditorPlugin>();
-	EditorPlugins::add_by_type<Box2DShapeEditorPlugin>();
-	EditorPlugins::add_by_type<Box2DJointEditorPlugin>();
+	if (p_level == MODULE_INITIALIZATION_LEVEL_EDITOR) {
+		EditorPlugins::add_by_type<Box2DPolygonEditorPlugin>();
+		EditorPlugins::add_by_type<Box2DShapeEditorPlugin>();
+		EditorPlugins::add_by_type<Box2DJointEditorPlugin>();
+	}
 #endif
 }
 
-void unregister_godot_box2d_types() {
+void uninitialize_godot_box2d_module(ModuleInitializationLevel p_level) {
 }

--- a/register_types.h
+++ b/register_types.h
@@ -5,7 +5,9 @@
 * @author Brian Semrau
 */
 
-void register_godot_box2d_types();
-void unregister_godot_box2d_types();
+#include "modules/register_module_types.h"
+
+void initialize_godot_box2d_module(ModuleInitializationLevel p_level);
+void uninitialize_godot_box2d_module(ModuleInitializationLevel p_level);
 
 #endif // REGISTER_BOX2D_TYPES_H

--- a/scene/2d/box2d_area.cpp
+++ b/scene/2d/box2d_area.cpp
@@ -88,11 +88,6 @@ void Box2DArea::_notification(int p_what) {
 			last_step_xform = get_box2dworld_transform();
 		}
 
-		case Box2DWorld::NOTIFICATION_WORLD_STEPPED: {
-			// Don't sync physics position
-			// This allows areas to move with the scene transform under other physics objects
-		} break;
-
 		case NOTIFICATION_LOCAL_TRANSFORM_CHANGED: {
 			// Send new transform to physics
 			Transform2D new_xform = get_box2dworld_transform();

--- a/scene/2d/box2d_area.cpp
+++ b/scene/2d/box2d_area.cpp
@@ -47,23 +47,23 @@ void Box2DArea::_on_object_exited(Box2DCollisionObject *p_object) {
 	}
 }
 
-void Box2DArea::_on_fixture_entered(Box2DFixture *p_fixture) {
+void Box2DArea::_on_fixture_entered(Box2DFixture *p_fixture, Box2DFixture *p_self_fixture) {
 	const Box2DPhysicsBody *body = Object::cast_to<const Box2DPhysicsBody>(p_fixture->_get_owner_node());
 	const Box2DArea *area = Object::cast_to<const Box2DArea>(p_fixture->_get_owner_node());
 	if (body) {
-		emit_signal("body_fixture_entered", p_fixture);
+		emit_signal("body_fixture_entered", p_fixture, p_self_fixture);
 	} else if (area && area->is_monitorable()) {
-		emit_signal("area_fixture_entered", p_fixture);
+		emit_signal("area_fixture_entered", p_fixture, p_self_fixture);
 	}
 }
 
-void Box2DArea::_on_fixture_exited(Box2DFixture *p_fixture) {
+void Box2DArea::_on_fixture_exited(Box2DFixture *p_fixture, Box2DFixture *p_self_fixture) {
 	const Box2DPhysicsBody *body = Object::cast_to<const Box2DPhysicsBody>(p_fixture->_get_owner_node());
 	const Box2DArea *area = Object::cast_to<const Box2DArea>(p_fixture->_get_owner_node());
 	if (body) {
-		emit_signal("body_fixture_exited", p_fixture);
+		emit_signal("body_fixture_exited", p_fixture, p_self_fixture);
 	} else if (area && area->is_monitorable()) {
-		emit_signal("area_fixture_exited", p_fixture);
+		emit_signal("area_fixture_exited", p_fixture, p_self_fixture);
 	}
 }
 

--- a/scene/2d/box2d_area.cpp
+++ b/scene/2d/box2d_area.cpp
@@ -393,6 +393,8 @@ StringName Box2DArea::get_audio_bus_name() const {
 Box2DArea::Box2DArea() {
 	bodyDef.type = b2BodyType::b2_dynamicBody;
 	bodyDef.gravityScale = 0.0f;
+
+	set_monitoring(true);
 }
 
 Box2DArea::~Box2DArea() {

--- a/scene/2d/box2d_area.cpp
+++ b/scene/2d/box2d_area.cpp
@@ -171,7 +171,7 @@ void Box2DArea::_bind_methods() {
 
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "space_override", PROPERTY_HINT_ENUM, "Disabled,Combine,Combine-Replace,Replace,Replace-Combine"), "set_space_override_mode", "get_space_override_mode");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "gravity_point"), "set_gravity_is_point", "is_gravity_a_point");
-	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "gravity_distance_scale", PROPERTY_HINT_EXP_RANGE, "0,1024,0.001,or_greater"), "set_gravity_distance_scale", "get_gravity_distance_scale");
+	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "gravity_distance_scale", PROPERTY_HINT_RANGE, "0,1024,0.001,or_greater,exp"), "set_gravity_distance_scale", "get_gravity_distance_scale");
 	ADD_PROPERTY(PropertyInfo(Variant::VECTOR2, "gravity_vec"), "set_gravity_vector", "get_gravity_vector");
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "gravity", PROPERTY_HINT_RANGE, "-1024,1024,0.001"), "set_gravity", "get_gravity");
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "linear_damp", PROPERTY_HINT_RANGE, "0,100,0.001,or_greater"), "set_linear_damp", "get_linear_damp");
@@ -337,8 +337,8 @@ TypedArray<Node2D> Box2DArea::get_overlapping_bodies() const {
 	ret.resize(contact_monitor->entered_objects.size());
 
 	int idx = 0;
-	for (const ObjectID *key = contact_monitor->entered_objects.next(NULL); key; key = contact_monitor->entered_objects.next(key)) {
-		const Object *obj = ObjectDB::get_instance(*key);
+	for (const KeyValue<ObjectID, int> &E : contact_monitor->entered_objects) {
+		const Object *obj = ObjectDB::get_instance(E.key);
 		const Box2DPhysicsBody *body = Object::cast_to<const Box2DPhysicsBody>(obj);
 		if (body)
 			ret[idx++] = body;
@@ -355,8 +355,8 @@ TypedArray<Box2DArea> Box2DArea::get_overlapping_areas() const {
 	ret.resize(contact_monitor->entered_objects.size());
 
 	int idx = 0;
-	for (const ObjectID *key = contact_monitor->entered_objects.next(NULL); key; key = contact_monitor->entered_objects.next(key)) {
-		const Object *obj = ObjectDB::get_instance(*key);
+	for (const KeyValue<ObjectID, int> &E : contact_monitor->entered_objects) {
+		const Object *obj = ObjectDB::get_instance(E.key);
 		const Box2DArea *area = Object::cast_to<const Box2DArea>(obj);
 		if (area)
 			ret[idx++] = area;

--- a/scene/2d/box2d_area.cpp
+++ b/scene/2d/box2d_area.cpp
@@ -68,10 +68,10 @@ void Box2DArea::_on_fixture_exited(Box2DFixture *p_fixture, Box2DFixture *p_self
 }
 
 void Box2DArea::pre_step(float p_delta) {
-	Transform2D motion = last_step_xform.affine_inverse() * get_box2dworld_transform();
+	Transform2D current_xform = get_box2dworld_transform();
 
-	Vector2 lin_vel = motion.get_origin() / p_delta;
-	float ang_vel = motion.get_rotation() / p_delta;
+	Vector2 lin_vel = (current_xform.get_origin() - last_step_xform.get_origin()) / p_delta;
+	float ang_vel = (current_xform.get_rotation() - last_step_xform.get_rotation()) / p_delta;
 
 	b2Body *body = _get_b2Body();
 	if (body) {

--- a/scene/2d/box2d_area.h
+++ b/scene/2d/box2d_area.h
@@ -38,7 +38,7 @@ private:
 	real_t linear_damp = 0.1;
 	real_t angular_damp = 1;
 	int priority = 0;
-	bool monitoring = true;
+	bool monitoring = false;
 	bool monitorable = true;
 
 	bool audio_bus_override = false;

--- a/scene/2d/box2d_area.h
+++ b/scene/2d/box2d_area.h
@@ -56,7 +56,7 @@ private:
 protected:
 	void _notification(int p_what);
 	static void _bind_methods();
-	void _validate_property(PropertyInfo &property) const override;
+	void _validate_property(PropertyInfo &property) const;
 
 public:
 	void set_space_override_mode(SpaceOverride p_mode);

--- a/scene/2d/box2d_area.h
+++ b/scene/2d/box2d_area.h
@@ -48,8 +48,8 @@ private:
 
 	virtual void _on_object_entered(Box2DCollisionObject *p_object) override;
 	virtual void _on_object_exited(Box2DCollisionObject *p_object) override;
-	virtual void _on_fixture_entered(Box2DFixture *p_fixture) override;
-	virtual void _on_fixture_exited(Box2DFixture *p_fixture) override;
+	virtual void _on_fixture_entered(Box2DFixture *p_fixture, Box2DFixture *p_self_fixture) override;
+	virtual void _on_fixture_exited(Box2DFixture *p_fixture, Box2DFixture *p_self_fixture) override;
 
 	virtual void pre_step(float p_delta) override;
 

--- a/scene/2d/box2d_collision_object.cpp
+++ b/scene/2d/box2d_collision_object.cpp
@@ -43,7 +43,7 @@ bool Box2DCollisionObject::destroy_b2Body() {
 		ERR_FAIL_COND_V(!world_node->world, false);
 
 		// Destroy body
-		body->GetUserData().owner = NULL;
+		//body->GetUserData().owner = NULL;
 		world_node->world->DestroyBody(body);
 		body = NULL;
 

--- a/scene/2d/box2d_collision_object.cpp
+++ b/scene/2d/box2d_collision_object.cpp
@@ -138,6 +138,10 @@ bool Box2DCollisionObject::_is_contact_monitor_enabled() const {
 	return contact_monitor != NULL;
 }
 
+void Box2DCollisionObject::step(float p_delta) {
+	GDVIRTUAL_CALL(_world_step, p_delta);
+}
+
 void Box2DCollisionObject::_notification(int p_what) {
 	// TODO finalize implementation to imitate behavior from RigidBody2D and Kinematic (static too?)
 	switch (p_what) {
@@ -214,7 +218,9 @@ void Box2DCollisionObject::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_group_index"), &Box2DCollisionObject::get_group_index);
 
 	ClassDB::bind_method(D_METHOD("set_filter_data", "collision_layer", "collision_mask", "group_index"), &Box2DCollisionObject::set_filter_data);
-	
+
+	GDVIRTUAL_BIND(_world_step, "delta");
+
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "enabled"), "set_enabled", "is_enabled");
 	ADD_GROUP("Collision", "");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "collision_layer", PROPERTY_HINT_LAYERS_2D_PHYSICS), "set_collision_layer", "get_collision_layer");

--- a/scene/2d/box2d_collision_object.cpp
+++ b/scene/2d/box2d_collision_object.cpp
@@ -43,6 +43,7 @@ bool Box2DCollisionObject::destroy_b2Body() {
 		ERR_FAIL_COND_V(!world_node->world, false);
 
 		// Destroy body
+		body->GetUserData().owner = NULL;
 		world_node->world->DestroyBody(body);
 		body = NULL;
 
@@ -141,7 +142,12 @@ void Box2DCollisionObject::_notification(int p_what) {
 	// TODO finalize implementation to imitate behavior from RigidBody2D and Kinematic (static too?)
 	switch (p_what) {
 		case NOTIFICATION_PREDELETE: {
-			destroy_b2Body();
+			if (world_node) {
+				if (world_node->world) {
+					destroy_b2Body();
+				}
+				world_node->body_owners.erase(this);
+			}
 		} break;
 
 		case NOTIFICATION_ENTER_TREE: {
@@ -157,10 +163,10 @@ void Box2DCollisionObject::_notification(int p_what) {
 			if (new_world != world_node) {
 				// Destroy b2Body
 				if (world_node) {
-					destroy_b2Body();
-					if (world_node) {
-						world_node->body_owners.erase(this);
+					if (world_node->world) {
+						destroy_b2Body();
 					}
+					world_node->body_owners.erase(this);
 				}
 				world_node = new_world;
 				// Create b2Body

--- a/scene/2d/box2d_collision_object.cpp
+++ b/scene/2d/box2d_collision_object.cpp
@@ -218,8 +218,8 @@ void Box2DCollisionObject::_bind_methods() {
 	ADD_SIGNAL(MethodInfo("enabled_state_changed"));
 }
 
-TypedArray<String> Box2DCollisionObject::get_configuration_warnings() const {
-	TypedArray<String> warnings = Node2D::get_configuration_warnings();
+PackedStringArray Box2DCollisionObject::get_configuration_warnings() const {
+	PackedStringArray warnings = Node2D::get_configuration_warnings();
 
 	Node *_ancestor = get_parent();
 	Box2DWorld *new_world = NULL;
@@ -229,7 +229,7 @@ TypedArray<String> Box2DCollisionObject::get_configuration_warnings() const {
 	}
 
 	if (!new_world) {
-		warnings.push_back(TTR("Box2DCollisionObject only serves to provide bodies to a Box2DWorld node. Please only use it under the hierarchy of Box2DWorld."));
+		warnings.push_back(RTR("Box2DCollisionObject only serves to provide bodies to a Box2DWorld node. Please only use it under the hierarchy of Box2DWorld."));
 	}
 
 	bool has_fixture_child = false;
@@ -240,7 +240,7 @@ TypedArray<String> Box2DCollisionObject::get_configuration_warnings() const {
 		}
 	}
 	if (!has_fixture_child) {
-		warnings.push_back(TTR("This node has no fixture, so it can't collide or interact with other objects.\nConsider adding a Box2DFixture subtype as a child to define its shape."));
+		warnings.push_back(RTR("This node has no fixture, so it can't collide or interact with other objects.\nConsider adding a Box2DFixture subtype as a child to define its shape."));
 	}
 
 	return warnings;
@@ -302,10 +302,8 @@ Array Box2DCollisionObject::get_colliding_bodies() const {
 	ERR_FAIL_COND_V(!contact_monitor, Array());
 	Array ret;
 
-	List<ObjectID> keys;
-	contact_monitor->entered_objects.get_key_list(&keys);
-	for (int i = 0; i < keys.size(); i++) {
-		Object *node = ObjectDB::get_instance(keys[i]);
+	for (const KeyValue<ObjectID, int> &E : contact_monitor->entered_objects) {
+		Object *node = ObjectDB::get_instance(E.key);
 		if (node && Object::cast_to<Box2DCollisionObject>(node)) {
 			ret.append(node);
 		}

--- a/scene/2d/box2d_collision_object.h
+++ b/scene/2d/box2d_collision_object.h
@@ -3,7 +3,7 @@
 
 #include <core/io/resource.h>
 #include <core/object/object.h>
-#include <core/object/reference.h>
+#include <core/object/ref_counted.h>
 #include <core/templates/vset.h>
 #include <scene/2d/node_2d.h>
 
@@ -77,7 +77,7 @@ protected:
 	static void _bind_methods();
 
 public:
-	virtual TypedArray<String> get_configuration_warnings() const override;
+	virtual PackedStringArray get_configuration_warnings() const override;
 
 	// Moving to and from world transform
 	void set_box2dworld_transform(const Transform2D &p_transform);

--- a/scene/2d/box2d_collision_object.h
+++ b/scene/2d/box2d_collision_object.h
@@ -67,8 +67,8 @@ protected:
 
 	virtual void _on_object_entered(Box2DCollisionObject *p_object) = 0;
 	virtual void _on_object_exited(Box2DCollisionObject *p_object) = 0;
-	virtual void _on_fixture_entered(Box2DFixture *p_fixture) = 0;
-	virtual void _on_fixture_exited(Box2DFixture *p_fixture) = 0;
+	virtual void _on_fixture_entered(Box2DFixture *p_fixture, Box2DFixture *p_self_fixture) = 0;
+	virtual void _on_fixture_exited(Box2DFixture *p_fixture, Box2DFixture *p_self_fixture) = 0;
 
 	virtual void pre_step(float p_delta){};
 

--- a/scene/2d/box2d_collision_object.h
+++ b/scene/2d/box2d_collision_object.h
@@ -4,6 +4,7 @@
 #include <core/io/resource.h>
 #include <core/object/object.h>
 #include <core/object/ref_counted.h>
+#include <core/object/gdvirtual.gen.inc>
 #include <core/templates/vset.h>
 #include <scene/2d/node_2d.h>
 
@@ -71,10 +72,13 @@ protected:
 	virtual void _on_fixture_exited(Box2DFixture *p_fixture, Box2DFixture *p_self_fixture) = 0;
 
 	virtual void pre_step(float p_delta){};
+	virtual void step(float p_delta);
 
 protected:
 	void _notification(int p_what);
 	static void _bind_methods();
+
+	GDVIRTUAL1(_world_step, float);
 
 public:
 	virtual PackedStringArray get_configuration_warnings() const override;

--- a/scene/2d/box2d_fixtures.cpp
+++ b/scene/2d/box2d_fixtures.cpp
@@ -72,7 +72,7 @@ void Box2DFixture::create_b2Fixture(b2Fixture *&p_fixture_out, const b2FixtureDe
 	}
 
 	p_fixture_out->GetUserData().owner = this;
-	Box2DPhysicsBody *body_node = dynamic_cast<Box2DPhysicsBody *>(owner_node);
+	Box2DPhysicsBody *body_node = Object::cast_to<Box2DPhysicsBody>(owner_node);
 	if (body_node)
 		body_node->update_mass();
 }
@@ -115,7 +115,7 @@ bool Box2DFixture::destroy_b2() {
 		ERR_FAIL_COND_V(!owner_node, false);
 		if (owner_node->body) {
 			for (int i = 0; i < fixtures.size(); i++) {
-				fixtures[i]->GetUserData().owner = NULL;
+				//fixtures[i]->GetUserData().owner = NULL;
 				owner_node->body->DestroyFixture(fixtures[i]);
 			}
 			fixtures.clear();
@@ -203,8 +203,8 @@ void Box2DFixture::_notification(int p_what) {
 			}
 
 			Color draw_col;
-			Box2DPhysicsBody *body_node = dynamic_cast<Box2DPhysicsBody *>(owner_node);
-			//Box2DArea *area_node = dynamic_cast<Box2DArea *>(owner_node);
+			Box2DPhysicsBody *body_node = Object::cast_to<Box2DPhysicsBody>(owner_node);
+			//Box2DArea *area_node = Object::cast_to<Box2DArea>(owner_node);
 
 			if (!owner_node) {
 				draw_col = Color(1.0f, 0.0f, 0.0f);

--- a/scene/2d/box2d_fixtures.cpp
+++ b/scene/2d/box2d_fixtures.cpp
@@ -153,8 +153,8 @@ void Box2DFixture::_notification(int p_what) {
 			if (owner_node != new_owner) {
 				if (owner_node) {
 					if (owner_node->has_signal("sleeping_state_changed"))
-						owner_node->disconnect("sleeping_state_changed", Callable(this, "update"));
-					owner_node->disconnect("enabled_state_changed", Callable(this, "update"));
+						owner_node->disconnect("sleeping_state_changed", Callable(this, "queue_redraw"));
+					owner_node->disconnect("enabled_state_changed", Callable(this, "queue_redraw"));
 				}
 				destroy_b2();
 
@@ -162,9 +162,9 @@ void Box2DFixture::_notification(int p_what) {
 
 				if (owner_node) {
 					if (owner_node->has_signal("sleeping_state_changed")) {
-						owner_node->connect("sleeping_state_changed", Callable(this, "update"));
+						owner_node->connect("sleeping_state_changed", Callable(this, "queue_redraw"));
 					}
-					owner_node->connect("enabled_state_changed", Callable(this, "update"));
+					owner_node->connect("enabled_state_changed", Callable(this, "queue_redraw"));
 
 					if (Object::cast_to<Box2DArea>(owner_node)) {
 						set_sensor(true);
@@ -291,7 +291,7 @@ void Box2DFixture::update_shape() {
 		create_b2();
 	}
 
-	update();
+	queue_redraw();
 
 	if (Engine::get_singleton()->is_editor_hint()) {
 		update_configuration_warnings();
@@ -313,8 +313,8 @@ bool Box2DFixture::_edit_is_selected_on_click(const Point2 &p_point, double p_to
 }
 #endif
 
-TypedArray<String> Box2DFixture::get_configuration_warnings() const {
-	TypedArray<String> warnings = Node2D::get_configuration_warnings();
+PackedStringArray Box2DFixture::get_configuration_warnings() const {
+	PackedStringArray warnings = Node2D::get_configuration_warnings();
 
 	// Find the parent body
 	Node *_ancestor = get_parent();
@@ -325,7 +325,7 @@ TypedArray<String> Box2DFixture::get_configuration_warnings() const {
 	}
 
 	if (!parent_body) {
-		warnings.push_back(TTR("Box2DFixture only serves to provide collision fixtures to a Box2DCollisionObject node. Please use it within the child hierarchy of Box2DPhysicsBody or Box2DArea to give it collision."));
+		warnings.push_back(RTR("Box2DFixture only serves to provide collision fixtures to a Box2DCollisionObject node. Please use it within the child hierarchy of Box2DPhysicsBody or Box2DArea to give it collision."));
 	}
 
 	return warnings;
@@ -341,12 +341,12 @@ TypedArray<String> Box2DFixture::get_configuration_warnings() const {
 
 void Box2DFixture::set_shape(const Ref<Box2DShape> &p_shape) {
 	if (shape.is_valid()) {
-		shape->disconnect("changed", Callable(this, "_shape_changed"));
+		shape->disconnect("changed", callable_mp(this, &Box2DFixture::_shape_changed));
 	}
 	shape = p_shape;
 
 	if (shape.is_valid()) {
-		shape->connect("changed", Callable(this, "_shape_changed"));
+		shape->connect("changed", callable_mp(this, &Box2DFixture::_shape_changed));
 	}
 
 	emit_signal("_shape_type_changed");

--- a/scene/2d/box2d_fixtures.cpp
+++ b/scene/2d/box2d_fixtures.cpp
@@ -115,6 +115,7 @@ bool Box2DFixture::destroy_b2() {
 		ERR_FAIL_COND_V(!owner_node, false);
 		if (owner_node->body) {
 			for (int i = 0; i < fixtures.size(); i++) {
+				fixtures[i]->GetUserData().owner = NULL;
 				owner_node->body->DestroyFixture(fixtures[i]);
 			}
 			fixtures.clear();

--- a/scene/2d/box2d_fixtures.h
+++ b/scene/2d/box2d_fixtures.h
@@ -2,7 +2,7 @@
 #define BOX2D_FIXTURES_H
 
 #include <core/object/object.h>
-#include <core/object/reference.h>
+#include <core/object/ref_counted.h>
 #include <core/io/resource.h>
 #include <scene/2d/node_2d.h>
 
@@ -61,9 +61,11 @@ protected:
 public:
 	inline const Box2DCollisionObject *_get_owner_node() const { return owner_node; }
 
+#ifdef TOOLS_ENABLED
 	virtual bool _edit_is_selected_on_click(const Point2 &p_point, double p_tolerance) const override;
+#endif
 
-	virtual TypedArray<String> get_configuration_warnings() const override;
+	virtual PackedStringArray get_configuration_warnings() const override;
 
 	Box2DCollisionObject *get_owner() const { return owner_node; }
 

--- a/scene/2d/box2d_joints.cpp
+++ b/scene/2d/box2d_joints.cpp
@@ -287,21 +287,6 @@ void Box2DJoint::_notification(int p_what) {
 		} break;
 #endif
 
-		case Box2DWorld::NOTIFICATION_WORLD_STEPPED: {
-			if (breaking_enabled && joint) {
-				Vector2 force = get_reaction_force();
-				real_t torque = abs(get_reaction_torque());
-
-				const bool exceeded_force = max_force > 0 && force.length() > max_force;
-				const bool exceeded_torque = max_torque > 0 && torque > max_torque;
-
-				if (exceeded_force || exceeded_torque) {
-					emit_signal("joint_broken", force, torque);
-					set_broken(true);
-				}
-			}
-		} break;
-
 		case NOTIFICATION_INTERNAL_PROCESS: {
 			// Leaving on for now, but ideally we only want to queue_redraw() when the actual display of something will change
 			if (Engine::get_singleton()->is_editor_hint() || get_tree()->is_debugging_collisions_hint()) {
@@ -479,6 +464,23 @@ void Box2DJoint::reset_joint_anchors() {
 
 	if (recreate)
 		recreate_joint(true);
+}
+
+void Box2DJoint::step(float p_delta) {
+	if (breaking_enabled && joint) {
+		Vector2 force = get_reaction_force();
+		real_t torque = abs(get_reaction_torque());
+
+		const bool exceeded_force = max_force > 0 && force.length() > max_force;
+		const bool exceeded_torque = max_torque > 0 && torque > max_torque;
+
+		if (exceeded_force || exceeded_torque) {
+			emit_signal("joint_broken", force, torque);
+			set_broken(true);
+		}
+	}
+
+	GDVIRTUAL_CALL(_world_step, p_delta);
 }
 
 void Box2DJoint::set_collide_connected(bool p_collide) {

--- a/scene/2d/box2d_joints.cpp
+++ b/scene/2d/box2d_joints.cpp
@@ -93,6 +93,7 @@ void Box2DJoint::on_node_predelete(Box2DPhysicsBody *node) {
 	set_process_internal(false);
 }
 
+#ifdef TOOLS_ENABLED
 void Box2DJoint::on_editor_transforms_changed() {
 	// TODO this is probably where to fix ticket #1
 
@@ -110,6 +111,7 @@ void Box2DJoint::on_editor_transforms_changed() {
 		//queue_redraw();
 	}
 }
+#endif
 
 void Box2DJoint::update_joint_bodies() {
 	// This is called whenever the joint's body nodes are reassigned via set_node_a/b.
@@ -274,6 +276,7 @@ void Box2DJoint::_notification(int p_what) {
 			update_joint_bodies();
 		} break;
 
+#ifdef TOOLS_ENABLED
 		case NOTIFICATION_TRANSFORM_CHANGED: {
 			// Changing transform only does anything if reinitialize_joint() is called
 
@@ -282,6 +285,7 @@ void Box2DJoint::_notification(int p_what) {
 				on_editor_transforms_changed();
 			}
 		} break;
+#endif
 
 		case Box2DWorld::NOTIFICATION_WORLD_STEPPED: {
 			if (breaking_enabled && joint) {
@@ -1133,6 +1137,7 @@ real_t Box2DPrismaticJoint::get_motor_force() const {
 Box2DPrismaticJoint::Box2DPrismaticJoint() :
 		Box2DJoint(&jointDef) {}
 
+//#ifdef TOOLS_ENABLED
 //void Box2DDistanceJoint::on_editor_transforms_changed() {
 	// TODO
 	//if (editor_translate_anchors) {
@@ -1150,6 +1155,7 @@ Box2DPrismaticJoint::Box2DPrismaticJoint() :
 	//	}
 	//}
 //}
+//#endif
 
 void Box2DDistanceJoint::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_anchor_a", "anchor_a"), &Box2DDistanceJoint::set_anchor_a);

--- a/scene/2d/box2d_joints.h
+++ b/scene/2d/box2d_joints.h
@@ -3,7 +3,7 @@
 
 #include <core/io/resource.h>
 #include <core/object/object.h>
-#include <core/object/reference.h>
+#include <core/object/ref_counted.h>
 #include <scene/2d/node_2d.h>
 
 #include <box2d/b2_distance_joint.h>
@@ -28,6 +28,7 @@
 */
 
 class Box2DWorld;
+class Box2DPhysicsBody;
 
 class Box2DJoint : public Node2D {
 	GDCLASS(Box2DJoint, Node2D);
@@ -112,7 +113,7 @@ protected:
 	void reset_joint_anchors();
 
 public:
-	virtual TypedArray<String> get_configuration_warnings() const override;
+	virtual PackedStringArray get_configuration_warnings() const override;
 
 	void set_nodepath_a(const NodePath &p_node_a);
 	NodePath get_nodepath_a() const;

--- a/scene/2d/box2d_joints.h
+++ b/scene/2d/box2d_joints.h
@@ -19,7 +19,9 @@
 #include <box2d/b2_weld_joint.h>
 #include <box2d/b2_wheel_joint.h>
 
+#ifdef TOOLS_ENABLED
 #include "../../editor/box2d_joint_editor_plugin.h"
+#endif
 #include "../../util/box2d_types_converter.h"
 #include "box2d_physics_body.h"
 
@@ -36,7 +38,9 @@ class Box2DJoint : public Node2D {
 	friend class Box2DWorld;
 	friend class Box2DPhysicsBody;
 
+#ifdef TOOLS_ENABLED
 	friend class Box2DJointEditor; // this is questionable TODO remove probably
+#endif
 
 	b2JointDef *jointDef = NULL;
 	b2Joint *joint = NULL;
@@ -62,7 +66,9 @@ class Box2DJoint : public Node2D {
 
 	void on_parent_created(Node *p_parent);
 	void on_node_predelete(Box2DPhysicsBody *node);
+#ifdef TOOLS_ENABLED
 	virtual void on_editor_transforms_changed();
+#endif
 
 	// Rescans the nodepaths to find b2Bodies and create our b2joint
 	void update_joint_bodies(); // TODO make virtual. Gear joint links joints, not bodies. Rename "update_joint_linkages/connections/nodepaths" or similar
@@ -71,7 +77,9 @@ class Box2DJoint : public Node2D {
 	void _node_b_tree_entered();
 
 protected:
+#ifdef TOOLS_ENABLED
 	Box2DJointEditor::AnchorMode editor_anchor_mode = Box2DJointEditor::AnchorMode::MODE_ANCHORS_LOCAL;
+#endif
 
 	// Destroys and recreates the b2Joint, if valid.
 	// Useful for modifying const b2 parameters, such as anchors. In these cases, set p_soft_reset to true.

--- a/scene/2d/box2d_joints.h
+++ b/scene/2d/box2d_joints.h
@@ -94,6 +94,8 @@ protected:
 	void _notification(int p_what);
 	static void _bind_methods();
 
+	GDVIRTUAL1(_world_step, float);
+
 	// Joint node local-space anchor points. These sync with jointDef's body-local anchor points.
 	// Allows configuring anchor points to be in different world positions when added to the scene.
 	// Modifying these is generally not recommended unless required for initializing a broken joint that starts separated.
@@ -119,6 +121,8 @@ protected:
 	Vector2 get_anchor_b() const;
 
 	void reset_joint_anchors();
+
+	void step(float p_delta);
 
 public:
 	virtual PackedStringArray get_configuration_warnings() const override;

--- a/scene/2d/box2d_physics_body.cpp
+++ b/scene/2d/box2d_physics_body.cpp
@@ -258,18 +258,18 @@ void Box2DPhysicsBody::_on_object_exited(Box2DCollisionObject *p_object) {
 	// ignore areas
 }
 
-void Box2DPhysicsBody::_on_fixture_entered(Box2DFixture *p_fixture) {
+void Box2DPhysicsBody::_on_fixture_entered(Box2DFixture *p_fixture, Box2DFixture *p_self_fixture) {
 	const Box2DPhysicsBody *body = Object::cast_to<const Box2DPhysicsBody>(p_fixture->_get_owner_node());
 	if (body) {
-		emit_signal("body_fixture_entered", p_fixture);
+		emit_signal("body_fixture_entered", p_fixture, p_self_fixture);
 	}
 	// ignore area fixtures
 }
 
-void Box2DPhysicsBody::_on_fixture_exited(Box2DFixture *p_fixture) {
+void Box2DPhysicsBody::_on_fixture_exited(Box2DFixture *p_fixture, Box2DFixture *p_self_fixture) {
 	const Box2DPhysicsBody *body = Object::cast_to<const Box2DPhysicsBody>(p_fixture->_get_owner_node());
 	if (body) {
-		emit_signal("body_fixture_exited", p_fixture);
+		emit_signal("body_fixture_exited", p_fixture, p_self_fixture);
 	}
 	// ignore area fixtures
 }

--- a/scene/2d/box2d_physics_body.cpp
+++ b/scene/2d/box2d_physics_body.cpp
@@ -478,12 +478,12 @@ void Box2DPhysicsBody::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_contact_normal_impulse", "idx"), &Box2DPhysicsBody::get_contact_normal_impulse);
 	ClassDB::bind_method(D_METHOD("get_contact_tangent_impulse", "idx"), &Box2DPhysicsBody::get_contact_tangent_impulse);
 
-	ClassDB::bind_method(D_METHOD("apply_force", "force", "point"), &Box2DPhysicsBody::apply_force, DEFVAL(true));
-	ClassDB::bind_method(D_METHOD("apply_central_force", "force"), &Box2DPhysicsBody::apply_central_force, DEFVAL(true));
-	ClassDB::bind_method(D_METHOD("apply_torque", "torque"), &Box2DPhysicsBody::apply_torque, DEFVAL(true));
-	ClassDB::bind_method(D_METHOD("apply_linear_impulse", "impulse", "point"), &Box2DPhysicsBody::apply_linear_impulse, DEFVAL(true));
-	ClassDB::bind_method(D_METHOD("apply_central_linear_impulse", "impulse"), &Box2DPhysicsBody::apply_central_linear_impulse, DEFVAL(true));
-	ClassDB::bind_method(D_METHOD("apply_torque_impulse", "impulse"), &Box2DPhysicsBody::apply_torque_impulse, DEFVAL(true));
+	ClassDB::bind_method(D_METHOD("apply_force", "force", "point", "wake"), &Box2DPhysicsBody::apply_force, DEFVAL(true));
+	ClassDB::bind_method(D_METHOD("apply_central_force", "force", "wake"), &Box2DPhysicsBody::apply_central_force, DEFVAL(true));
+	ClassDB::bind_method(D_METHOD("apply_torque", "torque", "wake"), &Box2DPhysicsBody::apply_torque, DEFVAL(true));
+	ClassDB::bind_method(D_METHOD("apply_linear_impulse", "impulse", "point", "wake"), &Box2DPhysicsBody::apply_linear_impulse, DEFVAL(true));
+	ClassDB::bind_method(D_METHOD("apply_central_linear_impulse", "impulse", "wake"), &Box2DPhysicsBody::apply_central_linear_impulse, DEFVAL(true));
+	ClassDB::bind_method(D_METHOD("apply_torque_impulse", "impulse", "wake"), &Box2DPhysicsBody::apply_torque_impulse, DEFVAL(true));
 
 	ClassDB::bind_method(D_METHOD("set_integrate_position", "enabled"), &Box2DPhysicsBody::set_integrate_position);
 	ClassDB::bind_method(D_METHOD("is_integrate_position_enabled"), &Box2DPhysicsBody::is_integrate_position_enabled);
@@ -519,7 +519,7 @@ void Box2DPhysicsBody::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "sync_to_physics"), "set_sync_to_physics", "is_sync_to_physics_enabled");
 	ADD_GROUP("Linear", "linear_");
 	ADD_PROPERTY(PropertyInfo(Variant::VECTOR2, "linear_velocity"), "set_linear_velocity", "get_linear_velocity");
-	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "linear_damping", PROPERTY_HINT_RANGE, "-1,1,0.001"), "set_linear_damping", "get_linear_damping");
+	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "linear_damping"), "set_linear_damping", "get_linear_damping");
 	ADD_GROUP("Angular", "angular_");
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "angular_velocity"), "set_angular_velocity", "get_angular_velocity");
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "angular_damping"), "set_angular_damping", "get_angular_damping");

--- a/scene/2d/box2d_physics_body.cpp
+++ b/scene/2d/box2d_physics_body.cpp
@@ -141,10 +141,6 @@ void Box2DPhysicsBody::sync_state() {
 	set_block_transform_notify(true);
 	set_box2dworld_transform(physics_xform);
 	set_block_transform_notify(false);
-
-	// At the moment, code meant for "_integrate_forces" goes in _physics_process
-	//if (get_script_instance())
-	//	get_script_instance()->call("_integrate_forces");
 }
 
 void Box2DPhysicsBody::teleport(const Transform2D &p_transform) {

--- a/scene/2d/box2d_physics_body.cpp
+++ b/scene/2d/box2d_physics_body.cpp
@@ -365,6 +365,7 @@ void Box2DPhysicsBody::_notification(int p_what) {
 				}
 			}
 
+#ifdef TOOLS_ENABLED
 			// Inform joints in editor that we moved
 			if (Engine::get_singleton()->is_editor_hint()) {
 				auto joint = joints.front();
@@ -373,6 +374,7 @@ void Box2DPhysicsBody::_notification(int p_what) {
 					joint = joint->next();
 				}
 			}
+#endif
 		} break;
 
 		case Box2DWorld::NOTIFICATION_WORLD_STEPPED: {

--- a/scene/2d/box2d_physics_body.cpp
+++ b/scene/2d/box2d_physics_body.cpp
@@ -120,6 +120,22 @@ void Box2DPhysicsBody::pre_step(float p_delta) {
 	_update_area_effects();
 }
 
+void Box2DPhysicsBody::step(float p_delta) {
+	Box2DCollisionObject::step(p_delta);
+
+	if (_get_b2Body()) {
+		const bool awake = _get_b2Body()->IsAwake();
+		if (awake != prev_sleeping_state) {
+			emit_signal("sleeping_state_changed");
+			prev_sleeping_state = awake;
+		}
+
+		if (get_type() == Mode::MODE_RIGID || (get_type() == Mode::MODE_KINEMATIC && (sync_to_physics || integrate_position))) {
+			sync_state();
+		}
+	}
+}
+
 void Box2DPhysicsBody::sync_state() {
 	const Transform2D physics_xform = b2_to_gd(_get_b2Body()->GetTransform());
 	set_block_transform_notify(true);
@@ -375,20 +391,6 @@ void Box2DPhysicsBody::_notification(int p_what) {
 				}
 			}
 #endif
-		} break;
-
-		case Box2DWorld::NOTIFICATION_WORLD_STEPPED: {
-			if (_get_b2Body()) {
-				const bool awake = _get_b2Body()->IsAwake();
-				if (awake != prev_sleeping_state) {
-					emit_signal("sleeping_state_changed");
-					prev_sleeping_state = awake;
-				}
-
-				if (get_type() == Mode::MODE_RIGID || (get_type() == Mode::MODE_KINEMATIC && (sync_to_physics || integrate_position))) {
-					sync_state();
-				}
-			}
 		} break;
 
 		case NOTIFICATION_INTERNAL_PROCESS: {

--- a/scene/2d/box2d_physics_body.cpp
+++ b/scene/2d/box2d_physics_body.cpp
@@ -853,37 +853,44 @@ int Box2DPhysicsBody::get_contact_count() const {
 }
 
 Box2DFixture *Box2DPhysicsBody::get_contact_fixture_a(int p_idx) const {
-	ERR_FAIL_COND_V_MSG(!contact_monitor, NULL, "Contact monitoring is disabled.");
+	ERR_FAIL_COND_V_MSG(!contact_monitor, nullptr, "Contact monitoring is disabled.");
+	ERR_FAIL_INDEX_V(p_idx, contact_monitor->contacts.size(), nullptr);
 	return contact_monitor->contacts[p_idx].fixture_a;
 }
 
 Box2DFixture *Box2DPhysicsBody::get_contact_fixture_b(int p_idx) const {
-	ERR_FAIL_COND_V_MSG(!contact_monitor, NULL, "Contact monitoring is disabled.");
+	ERR_FAIL_COND_V_MSG(!contact_monitor, nullptr, "Contact monitoring is disabled.");
+	ERR_FAIL_INDEX_V(p_idx, contact_monitor->contacts.size(), nullptr);
 	return contact_monitor->contacts[p_idx].fixture_b;
 }
 
 Vector2 Box2DPhysicsBody::get_contact_world_pos(int p_idx) const {
 	ERR_FAIL_COND_V_MSG(!contact_monitor, Vector2(), "Contact monitoring is disabled.");
+	ERR_FAIL_INDEX_V(p_idx, contact_monitor->contacts.size(), Vector2());
 	return contact_monitor->contacts[p_idx].world_pos;
 }
 
 Vector2 Box2DPhysicsBody::get_contact_impact_velocity(int p_idx) const {
 	ERR_FAIL_COND_V_MSG(!contact_monitor, Vector2(), "Contact monitoring is disabled.");
+	ERR_FAIL_INDEX_V(p_idx, contact_monitor->contacts.size(), Vector2());
 	return contact_monitor->contacts[p_idx].impact_velocity;
 }
 
 Vector2 Box2DPhysicsBody::get_contact_normal(int p_idx) const {
 	ERR_FAIL_COND_V_MSG(!contact_monitor, Vector2(), "Contact monitoring is disabled.");
+	ERR_FAIL_INDEX_V(p_idx, contact_monitor->contacts.size(), Vector2());
 	return contact_monitor->contacts[p_idx].normal;
 }
 
 float Box2DPhysicsBody::get_contact_normal_impulse(int p_idx) const {
 	ERR_FAIL_COND_V_MSG(!contact_monitor, float(), "Contact monitoring is disabled.");
+	ERR_FAIL_INDEX_V(p_idx, contact_monitor->contacts.size(), float());
 	return contact_monitor->contacts[p_idx].normal_impulse;
 }
 
 Vector2 Box2DPhysicsBody::get_contact_tangent_impulse(int p_idx) const {
 	ERR_FAIL_COND_V_MSG(!contact_monitor, Vector2(), "Contact monitoring is disabled.");
+	ERR_FAIL_INDEX_V(p_idx, contact_monitor->contacts.size(), Vector2());
 	return contact_monitor->contacts[p_idx].tangent_impulse;
 }
 

--- a/scene/2d/box2d_physics_body.h
+++ b/scene/2d/box2d_physics_body.h
@@ -3,7 +3,7 @@
 
 #include <core/io/resource.h>
 #include <core/object/object.h>
-#include <core/object/reference.h>
+#include <core/object/ref_counted.h>
 #include <core/templates/vset.h>
 #include <scene/2d/node_2d.h>
 
@@ -59,7 +59,7 @@ private:
 	VSet<Box2DPhysicsBody *> filtering_me;
 	// TODO i don't care enough right now to let bodies exclude specific fixtures
 
-	Set<Box2DJoint *> joints;
+	RBSet<Box2DJoint *> joints;
 
 	Transform2D last_valid_xform;
 
@@ -132,7 +132,7 @@ public:
 	void _remove_area(Box2DArea *p_area);
 	void _remove_area_variant(const Variant &p_area);
 
-	virtual TypedArray<String> get_configuration_warnings() const override;
+	virtual PackedStringArray get_configuration_warnings() const override;
 
 	void _set_linear_velocity_no_check(const Vector2 &p_vel);
 	void set_linear_velocity(const Vector2 &p_vel);
@@ -225,8 +225,8 @@ public:
 	bool test_move(const Transform2D &p_from, const Vector2 &p_motion, bool p_infinite_inertia = true);
 
 	// TODO missing rotation param, maybe pass a Transform2D
-	Vector2 move_and_slide(const Vector2 &p_linear_velocity, const Vector2 &p_up_direction = Vector2(0, 0), bool p_stop_on_slope = false, int p_max_slides = 4, float p_floor_max_angle = Math::deg2rad(45.0f), bool p_infinite_inertia = true);
-	Vector2 move_and_slide_with_snap(const Vector2 &p_linear_velocity, const Vector2 &p_snap, const Vector2 &p_up_direction = Vector2(0, 0), bool p_stop_on_slope = false, int p_max_slides = 4, float p_floor_max_angle = Math::deg2rad(45.0f), bool p_infinite_inertia = true);
+	Vector2 move_and_slide(const Vector2 &p_linear_velocity, const Vector2 &p_up_direction = Vector2(0, 0), bool p_stop_on_slope = false, int p_max_slides = 4, float p_floor_max_angle = Math::deg_to_rad(45.0f), bool p_infinite_inertia = true);
+	Vector2 move_and_slide_with_snap(const Vector2 &p_linear_velocity, const Vector2 &p_snap, const Vector2 &p_up_direction = Vector2(0, 0), bool p_stop_on_slope = false, int p_max_slides = 4, float p_floor_max_angle = Math::deg_to_rad(45.0f), bool p_infinite_inertia = true);
 	bool is_on_floor() const;
 	bool is_on_wall() const;
 	bool is_on_ceiling() const;
@@ -245,8 +245,8 @@ public:
 
 VARIANT_ENUM_CAST(Box2DPhysicsBody::Mode);
 
-class Box2DKinematicCollision : public Reference {
-	GDCLASS(Box2DKinematicCollision, Reference);
+class Box2DKinematicCollision : public RefCounted {
+	GDCLASS(Box2DKinematicCollision, RefCounted);
 
 	friend class Box2DPhysicsBody;
 

--- a/scene/2d/box2d_physics_body.h
+++ b/scene/2d/box2d_physics_body.h
@@ -122,6 +122,7 @@ protected:
 	virtual void on_b2Body_created() override;
 
 	virtual void pre_step(float p_delta) override;
+	virtual void step(float p_delta) override;
 
 protected:
 	void _notification(int p_what);

--- a/scene/2d/box2d_physics_body.h
+++ b/scene/2d/box2d_physics_body.h
@@ -111,8 +111,8 @@ private:
 
 	virtual void _on_object_entered(Box2DCollisionObject *p_object) override;
 	virtual void _on_object_exited(Box2DCollisionObject *p_object) override;
-	virtual void _on_fixture_entered(Box2DFixture *p_fixture) override;
-	virtual void _on_fixture_exited(Box2DFixture *p_fixture) override;
+	virtual void _on_fixture_entered(Box2DFixture *p_fixture, Box2DFixture *p_self_fixture) override;
+	virtual void _on_fixture_exited(Box2DFixture *p_fixture, Box2DFixture *p_self_fixture) override;
 
 private:
 	Ref<Box2DKinematicCollision> _move_and_collide_binding(const Vector2 &p_motion, const float p_rotation, const bool p_infinite_inertia = true, const bool p_exclude_raycast_shapes = true, const bool p_test_only = false);

--- a/scene/2d/box2d_world.cpp
+++ b/scene/2d/box2d_world.cpp
@@ -327,7 +327,7 @@ void Box2DWorld::BeginContact(b2Contact *contact) {
 		++(*fix_count_ptr);
 
 		if (*fix_count_ptr == 1) {
-			fixture_entered_queue.enqueue(body_a, fnode_b);
+			fixture_entered_queue.enqueue(body_a, fnode_b, fnode_a);
 		}
 	}
 	if (monitoringB) {
@@ -348,7 +348,7 @@ void Box2DWorld::BeginContact(b2Contact *contact) {
 		++(*fix_count_ptr);
 
 		if (*fix_count_ptr == 1) {
-			fixture_entered_queue.enqueue(body_b, fnode_a);
+			fixture_entered_queue.enqueue(body_b, fnode_a, fnode_b);
 		}
 	}
 }
@@ -384,9 +384,9 @@ void Box2DWorld::EndContact(b2Contact *contact) {
 		if ((*fix_count_ptr) == 0) {
 			body_a->contact_monitor->entered_objects.erase(fnode_b->get_instance_id());
 			if (queue_inout)
-				fixture_exited_queue.enqueue(body_a, fnode_b);
+				fixture_exited_queue.enqueue(body_a, fnode_b, fnode_a);
 			else
-				fixture_exited_queue.call_immediate(body_a, fnode_b);
+				fixture_exited_queue.call_immediate(body_a, fnode_b, fnode_a);
 		}
 	}
 	if (monitoringB) {
@@ -407,9 +407,9 @@ void Box2DWorld::EndContact(b2Contact *contact) {
 		if ((*fix_count_ptr) == 0) {
 			body_b->contact_monitor->entered_objects.erase(fnode_a->get_instance_id());
 			if (queue_inout)
-				fixture_exited_queue.enqueue(body_b, fnode_a);
+				fixture_exited_queue.enqueue(body_b, fnode_a, fnode_b);
 			else
-				fixture_exited_queue.call_immediate(body_b, fnode_a);
+				fixture_exited_queue.call_immediate(body_b, fnode_a, fnode_b);
 		}
 	}
 

--- a/scene/2d/box2d_world.cpp
+++ b/scene/2d/box2d_world.cpp
@@ -664,8 +664,6 @@ void Box2DWorld::_bind_methods() {
 
 	ADD_PROPERTY(PropertyInfo(Variant::VECTOR2, "gravity"), "set_gravity", "get_gravity");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "auto_step"), "set_auto_step", "get_auto_step");
-
-	BIND_CONSTANT(NOTIFICATION_WORLD_STEPPED);
 }
 
 inline void _get_aabb_from_shapes(const Vector<const b2Shape *> &p_b2shapes, const b2Transform &p_xform, b2AABB &r_aabb) {
@@ -1040,20 +1038,26 @@ void Box2DWorld::step(float p_step) {
 		obj->get()->pre_step(p_step);
 	}
 
-	// Step
+	// Step world
 	world->Step(p_step, 8, 8);
 	flag_rescan_contacts_monitored = false;
 
 	last_step_delta = p_step;
 
-	// Body/shape inout callbacks
+	// Step bodies/joints
+	for (RBSet<Box2DCollisionObject *>::Element *obj = body_owners.front(); obj; obj = obj->next()) {
+		obj->get()->step(p_step);
+	}
+	
+	for (RBSet<Box2DJoint *>::Element *joint = joint_owners.front(); joint; joint = joint->next()) {
+		joint->get()->step(p_step);
+	}
+
+	// Body/fixture inout callbacks
 	object_entered_queue.call_and_clear();
 	object_exited_queue.call_and_clear();
 	fixture_entered_queue.call_and_clear();
 	fixture_exited_queue.call_and_clear();
-
-	// Notify our bodies in this world
-	propagate_notification(NOTIFICATION_WORLD_STEPPED);
 }
 
 float Box2DWorld::get_last_step_delta() const {

--- a/scene/2d/box2d_world.cpp
+++ b/scene/2d/box2d_world.cpp
@@ -362,6 +362,9 @@ void Box2DWorld::EndContact(b2Contact *contact) {
 	const bool monitoringA = fnode_a->owner_node->_is_contact_monitor_enabled();
 	const bool monitoringB = fnode_b->owner_node->_is_contact_monitor_enabled();
 
+	// EndContact may occur outside of timestep. No need to defer signal calls when world is unlocked.
+	bool queue_inout = world->IsLocked();
+
 	// Deliver signals to bodies with contact monitoring enabled
 	if (monitoringA) {
 		int *body_count_ptr = body_a->contact_monitor->entered_objects.getptr(body_b->get_instance_id());
@@ -369,7 +372,10 @@ void Box2DWorld::EndContact(b2Contact *contact) {
 
 		if ((*body_count_ptr) == 0) {
 			body_a->contact_monitor->entered_objects.erase(body_b->get_instance_id());
-			object_exited_queue.enqueue(body_a, body_b);
+			if (queue_inout)
+				object_exited_queue.enqueue(body_a, body_b);
+			else
+				object_exited_queue.call_immediate(body_a, body_b);
 		}
 
 		int *fix_count_ptr = body_a->contact_monitor->entered_objects.getptr(fnode_b->get_instance_id());
@@ -377,7 +383,10 @@ void Box2DWorld::EndContact(b2Contact *contact) {
 
 		if ((*fix_count_ptr) == 0) {
 			body_a->contact_monitor->entered_objects.erase(fnode_b->get_instance_id());
-			fixture_exited_queue.enqueue(body_a, fnode_b);
+			if (queue_inout)
+				fixture_exited_queue.enqueue(body_a, fnode_b);
+			else
+				fixture_exited_queue.call_immediate(body_a, fnode_b);
 		}
 	}
 	if (monitoringB) {
@@ -386,7 +395,10 @@ void Box2DWorld::EndContact(b2Contact *contact) {
 
 		if ((*body_count_ptr) == 0) {
 			body_b->contact_monitor->entered_objects.erase(body_a->get_instance_id());
-			object_exited_queue.enqueue(body_b, body_a);
+			if (queue_inout)
+				object_exited_queue.enqueue(body_b, body_a);
+			else
+				object_exited_queue.call_immediate(body_b, body_a);
 		}
 
 		int *fix_count_ptr = body_b->contact_monitor->entered_objects.getptr(fnode_a->get_instance_id());
@@ -394,7 +406,10 @@ void Box2DWorld::EndContact(b2Contact *contact) {
 
 		if ((*fix_count_ptr) == 0) {
 			body_b->contact_monitor->entered_objects.erase(fnode_a->get_instance_id());
-			fixture_exited_queue.enqueue(body_b, fnode_a);
+			if (queue_inout)
+				fixture_exited_queue.enqueue(body_b, fnode_a);
+			else
+				fixture_exited_queue.call_immediate(body_b, fnode_a);
 		}
 	}
 

--- a/scene/2d/box2d_world.h
+++ b/scene/2d/box2d_world.h
@@ -278,6 +278,10 @@ private:
 			queue.push_back({ p_caller, p_transient });
 		}
 
+		inline void call_immediate(Box2DCollisionObject* p_caller, P* p_transient) {
+			(p_caller->*on_thing_inout)(p_transient);
+		}
+
 		inline void call_and_clear() {
 			while (!queue.empty()) {
 				CollisionUpdatePair *pair = &queue.front();

--- a/scene/2d/box2d_world.h
+++ b/scene/2d/box2d_world.h
@@ -3,8 +3,8 @@
 
 #include <core/io/resource.h>
 #include <core/object/object.h>
-#include <core/object/reference.h>
-#include <core/templates/set.h>
+#include <core/object/ref_counted.h>
+#include <core/templates/rb_set.h>
 #include <core/templates/vset.h>
 #include <scene/2d/node_2d.h>
 
@@ -101,7 +101,7 @@ class Box2DPhysicsBody;
 struct MotionQueryParameters {
 	Transform2D transform = Transform2D();
 
-	Set<const Box2DPhysicsBody *> exclude;
+	RBSet<const Box2DPhysicsBody *> exclude;
 	// potential addition: exclude fixtures
 	b2Filter filter; // TODO If/when we fork Box2D, filters get 32bit data
 	bool collide_with_bodies = true; // TODO might be better named as "collide_with_solids"
@@ -115,8 +115,8 @@ struct MotionQueryParameters {
 	//float motion_timedelta_for_prediction = 1/60;
 };
 
-class Box2DShapeQueryParameters : public Reference {
-	GDCLASS(Box2DShapeQueryParameters, Reference);
+class Box2DShapeQueryParameters : public RefCounted {
+	GDCLASS(Box2DShapeQueryParameters, RefCounted);
 
 	friend class Box2DWorld;
 
@@ -128,10 +128,10 @@ protected:
 
 public:
 	const b2Filter &_get_filter() const;
-	Set<const Box2DPhysicsBody *> _get_exclude() const;
+	RBSet<const Box2DPhysicsBody *> _get_exclude() const;
 
-	void set_shape(const RES &p_shape_ref);
-	RES get_shape() const;
+	void set_shape(const Ref<Resource> &p_shape_ref);
+	Ref<Resource> get_shape() const;
 
 	void set_transform(const Transform2D &p_transform);
 	Transform2D get_transform() const;
@@ -196,11 +196,11 @@ public:
 private:
 	class PointQueryCallback : public b2QueryCallback {
 	public:
-		Set<Box2DFixture *> results; // Use a set so composite fixtures don't double-count towards max_results
+		RBSet<Box2DFixture *> results; // Use a set so composite fixtures don't double-count towards max_results
 
 		b2Vec2 point;
 		int max_results;
-		Set<const Box2DPhysicsBody *> exclude;
+		RBSet<const Box2DPhysicsBody *> exclude;
 		b2Filter filter;
 		bool collide_with_bodies;
 		bool collide_with_sensors;
@@ -210,7 +210,7 @@ private:
 
 	class ShapeQueryCallback : public b2QueryCallback {
 	public:
-		Set<Box2DFixture *> results;
+		RBSet<Box2DFixture *> results;
 
 		Ref<Box2DShapeQueryParameters> params;
 		int max_results;
@@ -229,7 +229,7 @@ private:
 
 		Result result;
 
-		Set<const Box2DPhysicsBody *> exclude;
+		RBSet<const Box2DPhysicsBody *> exclude;
 		b2Filter filter;
 		bool collide_with_bodies;
 		bool collide_with_sensors;
@@ -301,8 +301,8 @@ private:
 	CollisionUpdateQueue<Box2DFixture, &Box2DCollisionObject::_on_fixture_exited> fixture_exited_queue;
 
 	// TODO make sure these are using the best data structure
-	Set<Box2DCollisionObject *> body_owners;
-	Set<Box2DJoint *> joint_owners;
+	RBSet<Box2DCollisionObject *> body_owners;
+	RBSet<Box2DJoint *> joint_owners;
 
 	// b2World Callbacks
 	// TODO extract into classes
@@ -402,8 +402,8 @@ public:
 	~Box2DWorld();
 };
 
-class Box2DPhysicsTestMotionResult : public Reference {
-	GDCLASS(Box2DPhysicsTestMotionResult, Reference);
+class Box2DPhysicsTestMotionResult : public RefCounted {
+	GDCLASS(Box2DPhysicsTestMotionResult, RefCounted);
 
 	friend class Box2DWorld;
 

--- a/scene/2d/box2d_world.h
+++ b/scene/2d/box2d_world.h
@@ -397,10 +397,6 @@ protected:
 	static void _bind_methods();
 
 public:
-	enum {
-		NOTIFICATION_WORLD_STEPPED = 42300, // special int that shouldn't clobber other notifications.  See node.h
-	};
-
 	void step(float p_step);
 
 	float get_last_step_delta() const;

--- a/scene/2d/box2d_world.h
+++ b/scene/2d/box2d_world.h
@@ -58,7 +58,7 @@ struct Box2DContactPoint {
 };
 
 struct ContactBufferManifold {
-	Box2DContactPoint points[b2_maxManifoldPoints];
+	Box2DContactPoint points[b2_maxManifoldPoints]{};
 
 	inline void set(Box2DContactPoint &p_point, int p_idx) {
 		ERR_FAIL_COND(p_idx < 0 || p_idx >= b2_maxManifoldPoints);
@@ -343,7 +343,7 @@ private:
 	bool flag_rescan_contacts_monitored = false;
 	HashMap<uint64_t, ContactBufferManifold> contact_buffer;
 
-	inline void try_buffer_contact(b2Contact *contact, int i);
+	inline ContactBufferManifold *try_buffer_contact(b2Contact *contact, int i);
 
 	virtual void BeginContact(b2Contact *contact) override;
 	virtual void EndContact(b2Contact *contact) override;

--- a/scene/2d/box2d_world.h
+++ b/scene/2d/box2d_world.h
@@ -62,11 +62,20 @@ struct ContactBufferManifold {
 
 	inline void set(Box2DContactPoint &p_point, int p_idx) {
 		ERR_FAIL_COND(p_idx < 0 || p_idx >= b2_maxManifoldPoints);
+		ERR_FAIL_COND(points[p_idx].id != -1);
 		points[p_idx] = p_point;
+	}
+
+	inline void swap() {
+		ERR_FAIL_COND(b2_maxManifoldPoints != 2); // affirm in case this ever changes(?) - swap algo would need to become smart
+		const Box2DContactPoint temp = points[0];
+		points[0] = points[1];
+		points[1] = temp;
 	}
 
 	inline void erase(int p_idx) {
 		ERR_FAIL_COND(p_idx < 0 || p_idx >= b2_maxManifoldPoints);
+		ERR_FAIL_COND(points[p_idx].id == -1);
 		points[p_idx].id = -1;
 	}
 

--- a/scene/2d/box2d_world.h
+++ b/scene/2d/box2d_world.h
@@ -59,39 +59,24 @@ struct Box2DContactPoint {
 
 struct ContactBufferManifold {
 	Box2DContactPoint points[b2_maxManifoldPoints];
-	int count = 0;
 
-	// TODO Optimize? These functions may be overkill, but everything currently works this way
-
-	inline void insert(Box2DContactPoint &p_point, int p_idx) {
-		ERR_FAIL_COND(count + 1 > b2_maxManifoldPoints);
+	inline void set(Box2DContactPoint &p_point, int p_idx) {
 		ERR_FAIL_COND(p_idx < 0 || p_idx >= b2_maxManifoldPoints);
-		ERR_FAIL_COND(p_idx > count); // Can't insert a point leaving a null at the index below
-
-		// Shift points up
-		if (p_idx < count) {
-			for (int i = count; i > p_idx; --i) {
-				points[i] = points[i - 1];
-			}
-		}
 		points[p_idx] = p_point;
-
-		++count;
 	}
 
-	inline void remove(int p_idx) {
-		ERR_FAIL_COND(p_idx < 0 || p_idx >= count || p_idx >= b2_maxManifoldPoints);
+	inline void erase(int p_idx) {
+		ERR_FAIL_COND(p_idx < 0 || p_idx >= b2_maxManifoldPoints);
+		points[p_idx].id = -1;
+	}
 
-		// Shift points down
-		if (p_idx < count - 1) {
-			for (int i = p_idx; i < count - 1; ++i) {
-				// There's a buffer overflow warning for this line but I don't believe it
-				points[i] = points[i + 1];
+	inline bool is_empty() {
+		for (int i = 0; i < b2_maxManifoldPoints; ++i) {
+			if (points[i].id != -1) {
+				return false;
 			}
-			points[count - 1].id = -1;
 		}
-
-		--count;
+		return true;
 	}
 };
 
@@ -397,7 +382,7 @@ protected:
 	static void _bind_methods();
 
 public:
-	void step(float p_step);
+	void step(float p_step, int32 velocity_iterations = 8, int32 position_iterations = 8);
 
 	float get_last_step_delta() const;
 

--- a/scene/2d/box2d_world.h
+++ b/scene/2d/box2d_world.h
@@ -264,28 +264,56 @@ private:
 		bool QueryCallback(int32 proxyId);
 	};
 	
-	template <class P, void (Box2DCollisionObject::*on_thing_inout)(P *)>
-	class CollisionUpdateQueue {
+	template <void (Box2DCollisionObject::*on_object_inout)(Box2DCollisionObject *)>
+	class ObjectCollisionUpdateQueue {
 	private:
 		struct CollisionUpdatePair {
 			Box2DCollisionObject *function_owner;
-			P *transient;
+			Box2DCollisionObject *transient;
 		};
 		std::deque<CollisionUpdatePair> queue{};
 
 	public:
-		inline void enqueue(Box2DCollisionObject *p_caller, P *p_transient) {
+		inline void enqueue(Box2DCollisionObject *p_caller, Box2DCollisionObject *p_transient) {
 			queue.push_back({ p_caller, p_transient });
 		}
 
-		inline void call_immediate(Box2DCollisionObject* p_caller, P* p_transient) {
-			(p_caller->*on_thing_inout)(p_transient);
+		inline void call_immediate(Box2DCollisionObject *p_caller, Box2DCollisionObject *p_transient) {
+			(p_caller->*on_object_inout)(p_transient);
 		}
 
 		inline void call_and_clear() {
 			while (!queue.empty()) {
 				CollisionUpdatePair *pair = &queue.front();
-				(pair->function_owner->*on_thing_inout)(pair->transient);
+				(pair->function_owner->*on_object_inout)(pair->transient);
+				queue.pop_front();
+			}
+		}
+	};
+
+	template <void (Box2DCollisionObject::*on_fixture_inout)(Box2DFixture *, Box2DFixture *)>
+	class FixtureCollisionUpdateQueue {
+	private:
+		struct CollisionUpdatePair {
+			Box2DCollisionObject *function_owner;
+			Box2DFixture *transient;
+			Box2DFixture *self;
+		};
+		std::deque<CollisionUpdatePair> queue{};
+
+	public:
+		inline void enqueue(Box2DCollisionObject *p_caller, Box2DFixture *p_transient, Box2DFixture *p_self) {
+			queue.push_back({ p_caller, p_transient, p_self });
+		}
+
+		inline void call_immediate(Box2DCollisionObject *p_caller, Box2DFixture *p_transient, Box2DFixture *p_self) {
+			(p_caller->*on_fixture_inout)(p_transient, p_self);
+		}
+
+		inline void call_and_clear() {
+			while (!queue.empty()) {
+				CollisionUpdatePair *pair = &queue.front();
+				(pair->function_owner->*on_fixture_inout)(pair->transient, pair->self);
 				queue.pop_front();
 			}
 		}
@@ -299,10 +327,10 @@ private:
 
 	float last_step_delta = 0.0f;
 
-	CollisionUpdateQueue<Box2DCollisionObject, &Box2DCollisionObject::_on_object_entered> object_entered_queue;
-	CollisionUpdateQueue<Box2DCollisionObject, &Box2DCollisionObject::_on_object_exited> object_exited_queue;
-	CollisionUpdateQueue<Box2DFixture, &Box2DCollisionObject::_on_fixture_entered> fixture_entered_queue;
-	CollisionUpdateQueue<Box2DFixture, &Box2DCollisionObject::_on_fixture_exited> fixture_exited_queue;
+	ObjectCollisionUpdateQueue<&Box2DCollisionObject::_on_object_entered> object_entered_queue;
+	ObjectCollisionUpdateQueue<&Box2DCollisionObject::_on_object_exited> object_exited_queue;
+	FixtureCollisionUpdateQueue<&Box2DCollisionObject::_on_fixture_entered> fixture_entered_queue;
+	FixtureCollisionUpdateQueue<&Box2DCollisionObject::_on_fixture_exited> fixture_exited_queue;
 
 	// TODO make sure these are using the best data structure
 	RBSet<Box2DCollisionObject *> body_owners;

--- a/scene/resources/box2d_shapes.cpp
+++ b/scene/resources/box2d_shapes.cpp
@@ -102,7 +102,7 @@ void Box2DCircleShape::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_radius", "radius"), &Box2DCircleShape::set_radius);
 	ClassDB::bind_method(D_METHOD("get_radius"), &Box2DCircleShape::get_radius);
 
-	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "radius", PROPERTY_HINT_RANGE, "0.5,16384,0.5,exp"), "set_radius", "get_radius");
+	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "radius", PROPERTY_HINT_RANGE, "0.5,16384,0.5,exp,or_greater"), "set_radius", "get_radius");
 }
 
 void Box2DCircleShape::set_radius(real_t p_radius) {
@@ -133,8 +133,8 @@ void Box2DRectShape::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_height"), &Box2DRectShape::get_height);
 
 	ADD_PROPERTY(PropertyInfo(Variant::VECTOR2, "size"), "set_size", "get_size");
-	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "width", PROPERTY_HINT_RANGE, "0.5,16384,0.5,exp"), "set_width", "get_width");
-	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "height", PROPERTY_HINT_RANGE, "0.5,16384,0.5,exp"), "set_height", "get_height");
+	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "width", PROPERTY_HINT_RANGE, "0.5,16384,0.5,exp,or_greater"), "set_width", "get_width");
+	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "height", PROPERTY_HINT_RANGE, "0.5,16384,0.5,exp,or_greater"), "set_height", "get_height");
 }
 
 void Box2DRectShape::set_size(const Vector2 &p_size) {
@@ -705,8 +705,8 @@ void Box2DCapsuleShape::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_radius", "radius"), &Box2DCapsuleShape::set_radius);
 	ClassDB::bind_method(D_METHOD("get_radius"), &Box2DCapsuleShape::get_radius);
 
-	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "height", PROPERTY_HINT_RANGE, "0.5,16384,0.5,exp"), "set_height", "get_height");
-	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "radius", PROPERTY_HINT_RANGE, "0.5,16384,0.5,exp"), "set_radius", "get_radius");
+	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "height", PROPERTY_HINT_RANGE, "0.5,16384,0.5,exp,or_greater"), "set_height", "get_height");
+	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "radius", PROPERTY_HINT_RANGE, "0.5,16384,0.5,exp,or_greater"), "set_radius", "get_radius");
 }
 
 void Box2DCapsuleShape::set_height(real_t p_height) {

--- a/scene/resources/box2d_shapes.cpp
+++ b/scene/resources/box2d_shapes.cpp
@@ -102,7 +102,7 @@ void Box2DCircleShape::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_radius", "radius"), &Box2DCircleShape::set_radius);
 	ClassDB::bind_method(D_METHOD("get_radius"), &Box2DCircleShape::get_radius);
 
-	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "radius", PROPERTY_HINT_EXP_RANGE, "0.5,16384,0.5"), "set_radius", "get_radius");
+	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "radius", PROPERTY_HINT_RANGE, "0.5,16384,0.5,exp"), "set_radius", "get_radius");
 }
 
 void Box2DCircleShape::set_radius(real_t p_radius) {
@@ -133,8 +133,8 @@ void Box2DRectShape::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_height"), &Box2DRectShape::get_height);
 
 	ADD_PROPERTY(PropertyInfo(Variant::VECTOR2, "size"), "set_size", "get_size");
-	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "width", PROPERTY_HINT_EXP_RANGE, "0.5,16384,0.5"), "set_width", "get_width");
-	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "height", PROPERTY_HINT_EXP_RANGE, "0.5,16384,0.5"), "set_height", "get_height");
+	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "width", PROPERTY_HINT_RANGE, "0.5,16384,0.5,exp"), "set_width", "get_width");
+	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "height", PROPERTY_HINT_RANGE, "0.5,16384,0.5,exp"), "set_height", "get_height");
 }
 
 void Box2DRectShape::set_size(const Vector2 &p_size) {
@@ -688,8 +688,8 @@ void Box2DPolygonShape::draw(const RID &p_to_rid, const Color &p_color) {
 
 Box2DPolygonShape::Box2DPolygonShape() :
 		build_mode(BuildMode::BUILD_SOLIDS),
-		chain_shape(NULL),
-		invert_order(false) {}
+		invert_order(false),
+		chain_shape(NULL) {}
 
 Box2DPolygonShape::~Box2DPolygonShape() {
 	memdelete_notnull(chain_shape);
@@ -705,8 +705,8 @@ void Box2DCapsuleShape::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_radius", "radius"), &Box2DCapsuleShape::set_radius);
 	ClassDB::bind_method(D_METHOD("get_radius"), &Box2DCapsuleShape::get_radius);
 
-	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "height", PROPERTY_HINT_EXP_RANGE, "0.5,16384,0.5"), "set_height", "get_height");
-	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "radius", PROPERTY_HINT_EXP_RANGE, "0.5,16384,0.5"), "set_radius", "get_radius");
+	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "height", PROPERTY_HINT_RANGE, "0.5,16384,0.5,exp"), "set_height", "get_height");
+	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "radius", PROPERTY_HINT_RANGE, "0.5,16384,0.5,exp"), "set_radius", "get_radius");
 }
 
 void Box2DCapsuleShape::set_height(real_t p_height) {

--- a/util/box2d_types_converter.h
+++ b/util/box2d_types_converter.h
@@ -5,6 +5,7 @@
 #include <core/math/vector2.h>
 #include <core/math/vector3.h>
 #include <core/typedefs.h>
+#include <core/config/project_settings.h>
 
 #include <box2d/b2_collision.h>
 #include <box2d/b2_math.h>


### PR DESCRIPTION
These are the minimal changes to make the module compile with the latest Godot 4.0.

Feedback and testing is welcome.

I noticed that Godot replaced the `HashMap` implementation, and `godot_box2d` at some points depends on the ordering of elements in a `HashMap`; I don't know if this requires any changes on the `godot_box2d` side.