### PR TITLE
Fix floating point imprecision breaking rotated shape queries

### DIFF
--- a/scene/2d/box2d_world.cpp
+++ b/scene/2d/box2d_world.cpp
@@ -91,7 +91,12 @@ RES Box2DShapeQueryParameters::get_shape() const {
 }
 
 void Box2DShapeQueryParameters::set_transform(const Transform2D &p_transform) {
-	ERR_FAIL_COND_MSG(p_transform.get_scale() != Size2(1, 1), "Box2DShapeQueryParameters does not support scaled transforms.");
+	#ifdef DEBUG_ENABLED
+	Vector2 s = p_transform.get_scale();
+	if (!s.is_equal_approx(Vector2(1.0,1.0))) {
+		WARN_PRINT("Box2DShapeQueryParameters does not support scaled transforms.");
+	}
+	#endif
 	parameters.transform = p_transform;
 }
 


### PR DESCRIPTION
Shape queries dont set their transform if
```
p_transform.get_scale() != Size2(1, 1)
```

This triggers random failures on rotated shape queries as floating point imprecision is unpredictable here. This commit changes the error checking to use is_equal_approx, and to still set the transform.

Possibly could remove the ifdef DEBUG_ENABLED, as most godot users wouldnt be running debug builds.